### PR TITLE
fix(auth): prevent privilege escalation by restricting registration role to staff (B1)

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -24,8 +24,7 @@ class AuthController extends Controller
      *             @OA\Property(property="name", type="string", example="John Doe"),
      *             @OA\Property(property="email", type="string", format="email", example="john@example.com"),
      *             @OA\Property(property="password", type="string", format="password", example="Password123!"),
-     *             @OA\Property(property="password_confirmation", type="string", format="password", example="Password123!"),
-     *             @OA\Property(property="role", type="string", enum={"admin", "staff"}, example="staff")
+     *             @OA\Property(property="password_confirmation", type="string", format="password", example="Password123!")
      *         )
      *     ),
      *     @OA\Response(
@@ -46,14 +45,13 @@ class AuthController extends Controller
             'name' => 'required|string|max:255',
             'email' => 'required|string|email|max:255|unique:users',
             'password' => ['required', 'string', 'confirmed', new StrongPassword()],
-            'role' => 'sometimes|in:admin,staff',
         ]);
 
         $user = User::create([
             'name' => $validated['name'],
             'email' => $validated['email'],
             'password' => Hash::make($validated['password']),
-            'role' => $validated['role'] ?? 'staff',
+            'role' => 'staff',
         ]);
 
         $token = $user->createToken('auth-token')->plainTextToken;

--- a/tests/Feature/AuthControllerTest.php
+++ b/tests/Feature/AuthControllerTest.php
@@ -29,6 +29,26 @@ class AuthControllerTest extends TestCase
 
         $this->assertDatabaseHas('users', [
             'email' => 'test@example.com',
+            'role' => 'staff',
+        ]);
+    }
+
+    public function test_registration_ignores_role_input_and_defaults_to_staff(): void
+    {
+        $response = $this->postJson('/api/auth/register', [
+            'name' => 'Attempted Admin',
+            'email' => 'attacker@example.com',
+            'password' => 'Test@1234',
+            'password_confirmation' => 'Test@1234',
+            'role' => 'admin',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('user.role', 'staff');
+
+        $this->assertDatabaseHas('users', [
+            'email' => 'attacker@example.com',
+            'role' => 'staff',
         ]);
     }
 
@@ -42,7 +62,7 @@ class AuthControllerTest extends TestCase
         ]);
 
         $response->assertStatus(422)
-            ->assertJsonValidationErrors(['password', 'password.min_length']);
+            ->assertJsonValidationErrors(['password']);
     }
 
     public function test_user_can_login_with_valid_credentials(): void


### PR DESCRIPTION
## Ringkasan Perubahan
Pull Request ini menyelesaikan bug keamanan kritis **[B1] Privilege Escalation** pada endpoint registrasi publik:

1. **Hapus Role dari Validasi Register:**
   - Menghapus `'role' => 'sometimes|in:admin,staff'` dari `AuthController::register()`.
   - Menghapus `@OA\Property(property="role"...)` dari OpenAPI Swagger documentation.
2. **Kunci Default Role ke Staff:**
   - Menetapkan `'role' => 'staff'` secara hardcoded pada `User::create()` di endpoint registrasi.
   - Pendaftaran akun `admin` kini hanya dapat dilakukan oleh Admin yang sudah terautentikasi melalui User Management (`UserController`).
3. **Automated Testing:**
   - Menambahkan test `test_registration_ignores_role_input_and_defaults_to_staff()` di `AuthControllerTest.php` untuk memverifikasi bahwa pengiriman parameter `role: "admin"` tetap menghasilkan akun ber-role `staff`.
   - Memperbaiki key assertion validation error pada `test_user_cannot_register_with_weak_password`.

Closes #7
