### PR TITLE
fix(user): validate active borrowings before user deletion (B6)

### DIFF
--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -93,6 +93,18 @@ class UserController extends Controller
             ], 400);
         }
 
+        // Prevent deleting user with active borrowings
+        $hasActiveBorrowings = $user->borrowings()
+            ->whereIn('status', ['dipinjam', 'terlambat'])
+            ->exists();
+
+        if ($hasActiveBorrowings) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Tidak dapat menghapus user yang masih memiliki peminjaman aktif'
+            ], 400);
+        }
+
         $user->delete();
 
         return response()->json([

--- a/database/factories/BorrowingFactory.php
+++ b/database/factories/BorrowingFactory.php
@@ -23,16 +23,15 @@ class BorrowingFactory extends Factory
         $dueDate = (clone $borrowDate)->modify('+7 days');
         
         return [
-            'code' => 'BRW-' . date('Y') . '-' . $this->faker->unique()->numerify('####'),
+            'borrow_code' => 'BRW-' . date('Y') . '-' . $this->faker->unique()->numerify('####'),
             'user_id' => User::factory(),
             'item_id' => Item::factory(),
             'quantity' => $this->faker->numberBetween(1, 5),
             'borrow_date' => $borrowDate,
             'due_date' => $dueDate,
             'return_date' => null,
-            'status' => $this->faker->randomElement(['pending', 'approved', 'returned', 'rejected']),
+            'status' => $this->faker->randomElement(['dipinjam', 'dikembalikan', 'terlambat']),
             'notes' => $this->faker->optional()->sentence(),
-            'return_condition' => null,
             'approved_by' => null,
         ];
     }

--- a/database/factories/ItemFactory.php
+++ b/database/factories/ItemFactory.php
@@ -30,7 +30,7 @@ class ItemFactory extends Factory
             'category_id' => Category::factory(),
             'stock' => $stock,
             'available_stock' => $stock,
-            'condition' => $this->faker->randomElement(['good', 'fair', 'poor']),
+            'condition' => $this->faker->randomElement(['baik', 'rusak', 'hilang']),
             'description' => $this->faker->optional()->sentence(),
             'image' => $this->faker->optional()->imageUrl(640, 480, 'technics'),
         ];

--- a/tests/Feature/UserControllerTest.php
+++ b/tests/Feature/UserControllerTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Borrowing;
+use App\Models\Category;
+use App\Models\Item;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $admin;
+    protected User $staff;
+    protected Item $item;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create(['role' => 'admin']);
+        $this->staff = User::factory()->create(['role' => 'staff']);
+
+        $category = Category::factory()->create();
+        $this->item = Item::factory()->create([
+            'category_id' => $category->id,
+            'stock' => 10,
+            'available_stock' => 10,
+            'condition' => 'baik',
+        ]);
+    }
+
+    /* =========================================================================
+     * ⚫ BLACK-BOX TESTING (API Contract, Status Codes & Authorization)
+     * ========================================================================= */
+
+    public function test_blackbox_guest_cannot_delete_user(): void
+    {
+        $targetUser = User::factory()->create(['role' => 'staff']);
+
+        $response = $this->deleteJson("/api/users/{$targetUser->id}");
+
+        $response->assertStatus(401);
+    }
+
+    public function test_blackbox_staff_cannot_delete_user(): void
+    {
+        $targetUser = User::factory()->create(['role' => 'staff']);
+
+        $response = $this->actingAs($this->staff)
+            ->deleteJson("/api/users/{$targetUser->id}");
+
+        $response->assertStatus(403);
+    }
+
+    public function test_blackbox_admin_cannot_delete_self(): void
+    {
+        $response = $this->actingAs($this->admin)
+            ->deleteJson("/api/users/{$this->admin->id}");
+
+        $response->assertStatus(400)
+            ->assertJson([
+                'success' => false,
+                'message' => 'Tidak dapat menghapus user sendiri',
+            ]);
+    }
+
+    public function test_blackbox_delete_user_with_active_borrowing_returns_400(): void
+    {
+        $targetUser = User::factory()->create(['role' => 'staff']);
+
+        Borrowing::factory()->create([
+            'user_id' => $targetUser->id,
+            'item_id' => $this->item->id,
+            'status' => 'dipinjam',
+        ]);
+
+        $response = $this->actingAs($this->admin)
+            ->deleteJson("/api/users/{$targetUser->id}");
+
+        $response->assertStatus(400)
+            ->assertJson([
+                'success' => false,
+                'message' => 'Tidak dapat menghapus user yang masih memiliki peminjaman aktif',
+            ]);
+    }
+
+    public function test_blackbox_delete_user_without_borrowings_returns_200(): void
+    {
+        $targetUser = User::factory()->create(['role' => 'staff']);
+
+        $response = $this->actingAs($this->admin)
+            ->deleteJson("/api/users/{$targetUser->id}");
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+                'message' => 'User berhasil dihapus',
+            ]);
+    }
+
+    /* =========================================================================
+     * ⚪ WHITE-BOX TESTING (Branch Coverage & Internal Logic Paths)
+     * ========================================================================= */
+
+    public function test_whitebox_branch_active_status_dipinjam_blocks_deletion(): void
+    {
+        $targetUser = User::factory()->create(['role' => 'staff']);
+
+        // Triggers whereIn('status', ['dipinjam', 'terlambat']) -> 'dipinjam' branch
+        Borrowing::factory()->create([
+            'user_id' => $targetUser->id,
+            'item_id' => $this->item->id,
+            'status' => 'dipinjam',
+        ]);
+
+        $response = $this->actingAs($this->admin)
+            ->deleteJson("/api/users/{$targetUser->id}");
+
+        $response->assertStatus(400);
+    }
+
+    public function test_whitebox_branch_active_status_terlambat_blocks_deletion(): void
+    {
+        $targetUser = User::factory()->create(['role' => 'staff']);
+
+        // Triggers whereIn('status', ['dipinjam', 'terlambat']) -> 'terlambat' branch
+        Borrowing::factory()->create([
+            'user_id' => $targetUser->id,
+            'item_id' => $this->item->id,
+            'status' => 'terlambat',
+        ]);
+
+        $response = $this->actingAs($this->admin)
+            ->deleteJson("/api/users/{$targetUser->id}");
+
+        $response->assertStatus(400);
+    }
+
+    public function test_whitebox_branch_completed_borrowing_dikembalikan_allows_deletion(): void
+    {
+        $targetUser = User::factory()->create(['role' => 'staff']);
+
+        // User has borrowings, but all are returned ('dikembalikan') -> condition evaluates to false
+        Borrowing::factory()->create([
+            'user_id' => $targetUser->id,
+            'item_id' => $this->item->id,
+            'status' => 'dikembalikan',
+        ]);
+
+        $response = $this->actingAs($this->admin)
+            ->deleteJson("/api/users/{$targetUser->id}");
+
+        $response->assertStatus(200);
+    }
+
+    /* =========================================================================
+     * 🔘 GREY-BOX TESTING (Database Integrity, State & Side Effects)
+     * ========================================================================= */
+
+    public function test_greybox_user_retained_in_database_when_deletion_is_blocked(): void
+    {
+        $targetUser = User::factory()->create(['role' => 'staff']);
+
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $targetUser->id,
+            'item_id' => $this->item->id,
+            'status' => 'dipinjam',
+        ]);
+
+        $this->actingAs($this->admin)
+            ->deleteJson("/api/users/{$targetUser->id}");
+
+        // Ensure database state was not altered
+        $this->assertDatabaseHas('users', [
+            'id' => $targetUser->id,
+            'email' => $targetUser->email,
+        ]);
+
+        $this->assertDatabaseHas('borrowings', [
+            'id' => $borrowing->id,
+            'status' => 'dipinjam',
+        ]);
+    }
+
+    public function test_greybox_user_removed_from_database_on_successful_deletion(): void
+    {
+        $targetUser = User::factory()->create(['role' => 'staff']);
+
+        $this->actingAs($this->admin)
+            ->deleteJson("/api/users/{$targetUser->id}");
+
+        // Ensure record was removed from users table
+        $this->assertDatabaseMissing('users', [
+            'id' => $targetUser->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Ringkasan Perubahan
Pull Request ini menyelesaikan bug **[B6] Validasi Hapus User** yang mencegah penghapusan user yang masih memiliki peminjaman barang aktif:

1. **Backend Validation:**
   - Menambahkan pengecekan `$user->borrowings()->whereIn('status', ['dipinjam', 'terlambat'])->exists()` pada `UserController::destroy()`.
   - Mengembalikan HTTP status `400 Bad Request` dan pesan `'Tidak dapat menghapus user yang masih memiliki peminjaman aktif'` jika peminjaman aktif terdeteksi.
2. **Model Factories Alignment:**
   - Menyelaraskan `BorrowingFactory` dan `ItemFactory` dengan schema migration database (`borrow_code`, enum `status` Indonesia, dan enum `condition` Indonesia).
3. **Advanced Testing Suite (3 Metodologi):**
   - Menambahkan test suite baru `UserControllerTest.php` dengan total **10 automated tests** (100% passing):
     - ⚫ **Black-Box Testing (5 tests):** Unauthenticated request (401), staff unauthorized request (403), admin delete self validation (400), active borrowing validation (400), dan successful deletion (200).
     - ⚪ **White-Box Testing (3 tests):** Branch coverage untuk status `dipinjam`, status `terlambat`, dan edge case status `dikembalikan` yang tetap diizinkan untuk dihapus.
     - 🔘 **Grey-Box Testing (2 tests):** Verifikasi database persistence (`assertDatabaseHas`) saat delete ditolak dan verifikasi database removal (`assertDatabaseMissing`) saat delete berhasil.

Closes #9
