### PR TITLE
fix(borrowing): resolve borrow_code field mismatch and search query (B3)

### DIFF
--- a/app/Exports/BorrowingsExport.php
+++ b/app/Exports/BorrowingsExport.php
@@ -65,7 +65,7 @@ class BorrowingsExport implements FromCollection, WithHeadings, WithMapping, Wit
     public function map($borrowing): array
     {
         return [
-            $borrowing->code,
+            $borrowing->borrow_code,
             $borrowing->user->name,
             $borrowing->item->name,
             $borrowing->item->category->name,

--- a/app/Http/Controllers/Api/BorrowingController.php
+++ b/app/Http/Controllers/Api/BorrowingController.php
@@ -20,7 +20,7 @@ class BorrowingController extends Controller
         if ($request->has('search')) {
             $search = $request->search;
             $query->where(function ($q) use ($search) {
-                $q->where('code', 'like', "%{$search}%")
+                $q->where('borrow_code', 'like', "%{$search}%")
                   ->orWhereHas('user', function ($q) use ($search) {
                       $q->where('name', 'like', "%{$search}%")
                         ->orWhere('email', 'like', "%{$search}%");

--- a/app/Http/Resources/BorrowingResource.php
+++ b/app/Http/Resources/BorrowingResource.php
@@ -16,7 +16,8 @@ class BorrowingResource extends JsonResource
     {
         return [
             'id' => $this->id,
-            'code' => $this->code,
+            'borrow_code' => $this->borrow_code,
+            'code' => $this->borrow_code,
             'user_id' => $this->user_id,
             'item_id' => $this->item_id,
             'quantity' => $this->quantity,

--- a/app/Models/Borrowing.php
+++ b/app/Models/Borrowing.php
@@ -43,6 +43,23 @@ class Borrowing extends Model
     ];
 
     /**
+     * The accessors to append to the model's array form.
+     *
+     * @var array<int, string>
+     */
+    protected $appends = [
+        'code',
+    ];
+
+    /**
+     * Get code attribute alias for borrow_code.
+     */
+    public function getCodeAttribute(): ?string
+    {
+        return $this->borrow_code;
+    }
+
+    /**
      * Get the user that owns the borrowing
      */
     public function user()

--- a/app/Services/BorrowingService.php
+++ b/app/Services/BorrowingService.php
@@ -28,7 +28,7 @@ class BorrowingService
             ->latest('id')
             ->first();
         
-        $sequence = $lastBorrowing ? ((int) substr($lastBorrowing->code, -4)) + 1 : 1;
+        $sequence = $lastBorrowing ? ((int) substr($lastBorrowing->borrow_code, -4)) + 1 : 1;
         
         return "BRW-{$date}-" . str_pad($sequence, 4, '0', STR_PAD_LEFT);
     }
@@ -38,7 +38,7 @@ class BorrowingService
      */
     public function createBorrowing(array $data, int $userId): Borrowing
     {
-        $data['code'] = $this->generateBorrowingCode();
+        $data['borrow_code'] = $this->generateBorrowingCode();
         $data['user_id'] = $userId;
         $data['status'] = 'pending';
 

--- a/app/Services/ReportService.php
+++ b/app/Services/ReportService.php
@@ -109,7 +109,8 @@ class ReportService
                 
                 return [
                     'id' => $borrowing->id,
-                    'code' => $borrowing->code,
+                    'borrow_code' => $borrowing->borrow_code,
+                    'code' => $borrowing->borrow_code,
                     'user' => $borrowing->user->name,
                     'user_email' => $borrowing->user->email,
                     'item' => $borrowing->item->name,
@@ -175,7 +176,8 @@ class ReportService
                 
                 return [
                     'id' => $borrowing->id,
-                    'code' => $borrowing->code,
+                    'borrow_code' => $borrowing->borrow_code,
+                    'code' => $borrowing->borrow_code,
                     'item' => $borrowing->item->name,
                     'quantity' => $borrowing->quantity,
                     'borrow_date' => $borrowDate->format('Y-m-d'),

--- a/tests/Feature/BorrowingCodeFieldTest.php
+++ b/tests/Feature/BorrowingCodeFieldTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Exports\BorrowingsExport;
+use App\Models\Borrowing;
+use App\Models\Category;
+use App\Models\Item;
+use App\Models\User;
+use App\Services\BorrowingService;
+use App\Services\ReportService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BorrowingCodeFieldTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $admin;
+    protected User $staff;
+    protected Item $item;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create(['role' => 'admin']);
+        $this->staff = User::factory()->create(['role' => 'staff']);
+
+        $category = Category::factory()->create();
+        $this->item = Item::factory()->create([
+            'category_id' => $category->id,
+            'stock' => 10,
+            'available_stock' => 10,
+            'condition' => 'baik',
+        ]);
+    }
+
+    /* =========================================================================
+     * ⚫ BLACK-BOX TESTING (API Search, JSON Contract & Status Codes)
+     * ========================================================================= */
+
+    public function test_blackbox_search_borrowing_by_code_does_not_crash(): void
+    {
+        $borrowing = Borrowing::create([
+            'borrow_code' => 'BRW-20260904-0001',
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'borrow_date' => now(),
+            'due_date' => now()->addDays(7),
+            'status' => 'dipinjam',
+        ]);
+
+        // Search using borrow_code prefix
+        $response = $this->actingAs($this->admin)
+            ->getJson('/api/borrowings?search=BRW-20260904');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.0.borrow_code', 'BRW-20260904-0001')
+            ->assertJsonPath('data.0.code', 'BRW-20260904-0001');
+    }
+
+    public function test_blackbox_borrowing_response_contains_both_code_and_borrow_code(): void
+    {
+        $borrowing = Borrowing::create([
+            'borrow_code' => 'BRW-20260904-0002',
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'borrow_date' => now(),
+            'due_date' => now()->addDays(7),
+            'status' => 'dipinjam',
+        ]);
+
+        $response = $this->actingAs($this->admin)
+            ->getJson("/api/borrowings/{$borrowing->id}");
+
+        $response->assertStatus(200);
+
+        $json = $response->json();
+        // Support either wrapped resource or direct model JSON
+        $data = $json['data'] ?? $json;
+
+        $this->assertEquals('BRW-20260904-0002', $data['borrow_code']);
+        $this->assertEquals('BRW-20260904-0002', $data['code']);
+    }
+
+    /* =========================================================================
+     * ⚪ WHITE-BOX TESTING (Model Accessor, Serialization & Logic)
+     * ========================================================================= */
+
+    public function test_whitebox_borrowing_model_code_accessor_returns_borrow_code(): void
+    {
+        $borrowing = new Borrowing([
+            'borrow_code' => 'BRW-20260904-9999',
+        ]);
+
+        // Direct property access via Eloquent accessor getCodeAttribute()
+        $this->assertEquals('BRW-20260904-9999', $borrowing->code);
+        $this->assertEquals('BRW-20260904-9999', $borrowing->borrow_code);
+    }
+
+    public function test_whitebox_borrowing_appends_code_in_array_and_json(): void
+    {
+        $borrowing = new Borrowing([
+            'borrow_code' => 'BRW-20260904-5555',
+        ]);
+
+        $array = $borrowing->toArray();
+        $this->assertArrayHasKey('code', $array);
+        $this->assertArrayHasKey('borrow_code', $array);
+        $this->assertEquals('BRW-20260904-5555', $array['code']);
+    }
+
+    public function test_whitebox_borrowing_service_generate_code_reads_borrow_code(): void
+    {
+        Borrowing::create([
+            'borrow_code' => 'BRW-' . now()->format('Ymd') . '-0005',
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'borrow_date' => now(),
+            'due_date' => now()->addDays(7),
+            'status' => 'dipinjam',
+        ]);
+
+        $service = app(BorrowingService::class);
+        $newCode = $service->generateBorrowingCode();
+
+        $expectedCode = 'BRW-' . now()->format('Ymd') . '-0006';
+        $this->assertEquals($expectedCode, $newCode);
+    }
+
+    /* =========================================================================
+     * 🔘 GREY-BOX TESTING (Database Integrity, Search Query & Report/Export Mapping)
+     * ========================================================================= */
+
+    public function test_greybox_search_matches_exact_database_borrow_code(): void
+    {
+        // Insert 2 records with distinct codes directly in database
+        Borrowing::create([
+            'borrow_code' => 'BRW-ALPHA-1234',
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'borrow_date' => now(),
+            'due_date' => now()->addDays(7),
+            'status' => 'dipinjam',
+        ]);
+
+        Borrowing::create([
+            'borrow_code' => 'BRW-BETA-5678',
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'borrow_date' => now(),
+            'due_date' => now()->addDays(7),
+            'status' => 'dipinjam',
+        ]);
+
+        // Search for ALPHA
+        $response = $this->actingAs($this->admin)
+            ->getJson('/api/borrowings?search=ALPHA');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.borrow_code', 'BRW-ALPHA-1234');
+
+        $this->assertDatabaseHas('borrowings', [
+            'borrow_code' => 'BRW-ALPHA-1234',
+        ]);
+    }
+
+    public function test_greybox_export_and_report_service_contain_borrow_code(): void
+    {
+        $borrowing = Borrowing::create([
+            'borrow_code' => 'BRW-EXP-001',
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'borrow_date' => now(),
+            'due_date' => now()->addDays(7),
+            'status' => 'dipinjam',
+        ]);
+
+        // Test BorrowingsExport mapping
+        $export = new BorrowingsExport([]);
+        $mapped = $export->map($borrowing);
+
+        $this->assertEquals('BRW-EXP-001', $mapped[0]);
+
+        // Test ReportService
+        $reportService = new ReportService();
+        $overdueData = $reportService->getOverdueBorrowings();
+
+        // Ensure report service didn't throw and structure is correct
+        $this->assertIsArray($overdueData);
+    }
+}


### PR DESCRIPTION
## Ringkasan Perubahan
Pull Request ini menyelesaikan bug **[B3] Field Mismatch `borrow_code` vs `code`**:

1. **Model Accessor & Serialization:**
   - Menambahkan `$appends = ['code']` dan `getCodeAttribute()` pada `Borrowing.php`.
   - Setiap serialisasi model `Borrowing` ke JSON/array kini secara otomatis memuat kedua field (`borrow_code` dan `code`), sehingga langsung memperbaiki tampilan kode kosong pada `BorrowingList.jsx`, `BorrowingDetail.jsx`, dan `Reports.jsx`.
2. **Fix Search Query Crash (500 SQL Error):**
   - Memperbaiki pencarian kode di `BorrowingController::index()` dari `where('code', ...)` menjadi `where('borrow_code', 'like', "%{$search}%")`.
3. **Standarisasi di Resource, Services, dan Export:**
   - Menyediakan `borrow_code` dan `code` di `BorrowingResource.php`.
   - Menyelaraskan field di `BorrowingsExport.php`, `BorrowingService.php`, dan `ReportService.php`.
4. **Advanced Testing Suite (3 Metodologi):**
   - Menambahkan `tests/Feature/BorrowingCodeFieldTest.php` dengan **7 automated tests** (100% pass):
     - ⚫ **Black-Box:** Search borrowing by code (200 OK tanpa SQL error) dan response JSON memuat kedua field dengan nilai identik.
     - ⚪ **White-Box:** Verifikasi accessor `Borrowing::getCodeAttribute()`, JSON array serialization, dan service sequence generator.
     - 🔘 **Grey-Box:** Database search match exact value pada kolom `borrow_code` dan mapping export/report service.

Closes #11
