### PR TITLE
fix(borrowing): prevent stock race conditions and ensure transaction atomicity (B2)

### DIFF
--- a/app/Http/Controllers/Api/BorrowingController.php
+++ b/app/Http/Controllers/Api/BorrowingController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Borrowing;
 use App\Models\Item;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 
 class BorrowingController extends Controller
 {
@@ -101,33 +102,43 @@ class BorrowingController extends Controller
             'notes' => 'nullable|string',
         ]);
 
-        $item = Item::findOrFail($validated['item_id']);
+        $result = DB::transaction(function () use ($validated, $request) {
+            $item = Item::lockForUpdate()->findOrFail($validated['item_id']);
 
-        // Check if item is available
-        if (!$item->isAvailable($validated['quantity'])) {
-            return response()->json([
-                'message' => 'Item is not available in requested quantity',
-                'available_stock' => $item->available_stock,
-            ], 422);
-        }
+            // Check if item is available
+            if (!$item->isAvailable($validated['quantity'])) {
+                return [
+                    'status' => 422,
+                    'payload' => [
+                        'message' => 'Item is not available in requested quantity',
+                        'available_stock' => $item->available_stock,
+                    ],
+                ];
+            }
 
-        // Generate unique code
-        $validated['borrow_code'] = Borrowing::generateCode();
-        $validated['user_id'] = $request->user()->id;
-        $validated['status'] = 'dipinjam';
+            // Generate unique code
+            $validated['borrow_code'] = Borrowing::generateCode();
+            $validated['user_id'] = $request->user()->id;
+            $validated['status'] = 'dipinjam';
 
-        // Create borrowing
-        $borrowing = Borrowing::create($validated);
+            // Create borrowing
+            $borrowing = Borrowing::create($validated);
 
-        // Update item stock
-        $item->decreaseStock($validated['quantity']);
+            // Update item stock
+            $item->decreaseStock($validated['quantity']);
 
-        $borrowing->load(['user', 'item', 'approver']);
+            $borrowing->load(['user', 'item', 'approver']);
 
-        return response()->json([
-            'message' => 'Borrowing created successfully',
-            'data' => $borrowing,
-        ], 201);
+            return [
+                'status' => 201,
+                'payload' => [
+                    'message' => 'Borrowing created successfully',
+                    'data' => $borrowing,
+                ],
+            ];
+        });
+
+        return response()->json($result['payload'], $result['status']);
     }
 
     /**
@@ -148,26 +159,42 @@ class BorrowingController extends Controller
      */
     public function return(Request $request, Borrowing $borrowing)
     {
-        if ($borrowing->status === 'dikembalikan') {
-            return response()->json([
-                'message' => 'Item already returned',
-            ], 422);
-        }
+        $result = DB::transaction(function () use ($borrowing) {
+            /** @var Borrowing $lockedBorrowing */
+            $lockedBorrowing = Borrowing::lockForUpdate()->findOrFail($borrowing->id);
 
-        $success = $borrowing->processReturn();
+            if ($lockedBorrowing->status === 'dikembalikan') {
+                return [
+                    'status' => 422,
+                    'payload' => [
+                        'message' => 'Item already returned',
+                    ],
+                ];
+            }
 
-        if (!$success) {
-            return response()->json([
-                'message' => 'Failed to process return',
-            ], 500);
-        }
+            $success = $lockedBorrowing->processReturn();
 
-        $borrowing->load(['user', 'item', 'approver']);
+            if (!$success) {
+                return [
+                    'status' => 500,
+                    'payload' => [
+                        'message' => 'Failed to process return',
+                    ],
+                ];
+            }
 
-        return response()->json([
-            'message' => 'Item returned successfully',
-            'data' => $borrowing,
-        ]);
+            $lockedBorrowing->load(['user', 'item', 'approver']);
+
+            return [
+                'status' => 200,
+                'payload' => [
+                    'message' => 'Item returned successfully',
+                    'data' => $lockedBorrowing,
+                ],
+            ];
+        });
+
+        return response()->json($result['payload'], $result['status']);
     }
 
     /**

--- a/app/Models/Borrowing.php
+++ b/app/Models/Borrowing.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Spatie\Activitylog\Traits\LogsActivity;
 use Spatie\Activitylog\LogOptions;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class Borrowing extends Model
 {
@@ -128,14 +129,26 @@ class Borrowing extends Model
             return false;
         }
 
-        $this->return_date = now();
-        $this->status = 'dikembalikan';
-        $this->save();
+        return DB::transaction(function () {
+            // Re-check after acquiring transaction to prevent race conditions
+            $this->refresh();
+            if ($this->status === 'dikembalikan') {
+                return false;
+            }
 
-        // Update item stock
-        $this->item->increaseStock($this->quantity);
+            $item = Item::lockForUpdate()->find($this->item_id);
 
-        return true;
+            $this->return_date = now();
+            $this->status = 'dikembalikan';
+            $this->save();
+
+            // Update item stock
+            if ($item) {
+                $item->increaseStock($this->quantity);
+            }
+
+            return true;
+        });
     }
 
     /**

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -75,6 +75,14 @@ class Item extends Model
      */
     public function decreaseStock(int $quantity): void
     {
+        if ($quantity <= 0) {
+            throw new \InvalidArgumentException('Quantity must be greater than zero.');
+        }
+
+        if ($this->available_stock < $quantity) {
+            throw new \InvalidArgumentException("Cannot decrease stock below zero. Current stock: {$this->available_stock}, requested: {$quantity}");
+        }
+
         $this->available_stock -= $quantity;
         $this->save();
     }
@@ -84,6 +92,10 @@ class Item extends Model
      */
     public function increaseStock(int $quantity): void
     {
+        if ($quantity <= 0) {
+            throw new \InvalidArgumentException('Quantity must be greater than zero.');
+        }
+
         $this->available_stock += $quantity;
         $this->save();
     }

--- a/database/factories/ItemFactory.php
+++ b/database/factories/ItemFactory.php
@@ -30,9 +30,29 @@ class ItemFactory extends Factory
             'category_id' => Category::factory(),
             'stock' => $stock,
             'available_stock' => $stock,
-            'condition' => $this->faker->randomElement(['baik', 'rusak', 'hilang']),
+            'condition' => 'baik',
             'description' => $this->faker->optional()->sentence(),
             'image' => $this->faker->optional()->imageUrl(640, 480, 'technics'),
         ];
+    }
+
+    /**
+     * Indicate that the item is damaged.
+     */
+    public function damaged(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'condition' => 'rusak',
+        ]);
+    }
+
+    /**
+     * Indicate that the item is lost.
+     */
+    public function lost(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'condition' => 'hilang',
+        ]);
     }
 }

--- a/tests/Feature/BorrowingStockRaceConditionTest.php
+++ b/tests/Feature/BorrowingStockRaceConditionTest.php
@@ -1,0 +1,416 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Borrowing;
+use App\Models\Category;
+use App\Models\Item;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class BorrowingStockRaceConditionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Category $category;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create([
+            'role' => 'staff',
+        ]);
+
+        $this->category = Category::factory()->create();
+    }
+
+    // ==========================================
+    // 1. BLACK-BOX TESTING (API & Functional)
+    // ==========================================
+
+    public function test_blackbox_user_can_create_borrowing_when_stock_is_sufficient(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'stock' => 10,
+            'available_stock' => 5,
+            'condition' => 'baik',
+        ]);
+
+        $response = $this->postJson('/api/borrowings', [
+            'item_id' => $item->id,
+            'quantity' => 2,
+            'borrow_date' => now()->toDateString(),
+            'due_date' => now()->addDays(3)->toDateString(),
+            'notes' => 'Peminjaman untuk keperluan testing',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJson([
+                'message' => 'Borrowing created successfully',
+            ])
+            ->assertJsonStructure([
+                'message',
+                'data' => [
+                    'id',
+                    'borrow_code',
+                    'user_id',
+                    'item_id',
+                    'quantity',
+                    'status',
+                ],
+            ]);
+
+        $this->assertEquals(3, $item->fresh()->available_stock);
+    }
+
+    public function test_blackbox_user_cannot_borrow_more_than_available_stock(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'stock' => 5,
+            'available_stock' => 2,
+            'condition' => 'baik',
+        ]);
+
+        $response = $this->postJson('/api/borrowings', [
+            'item_id' => $item->id,
+            'quantity' => 3,
+            'borrow_date' => now()->toDateString(),
+            'due_date' => now()->addDays(3)->toDateString(),
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'message' => 'Item is not available in requested quantity',
+                'available_stock' => 2,
+            ]);
+
+        $this->assertEquals(2, $item->fresh()->available_stock);
+    }
+
+    public function test_blackbox_user_cannot_borrow_item_with_damaged_condition(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'stock' => 5,
+            'available_stock' => 5,
+            'condition' => 'rusak',
+        ]);
+
+        $response = $this->postJson('/api/borrowings', [
+            'item_id' => $item->id,
+            'quantity' => 1,
+            'borrow_date' => now()->toDateString(),
+            'due_date' => now()->addDays(3)->toDateString(),
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'message' => 'Item is not available in requested quantity',
+                'available_stock' => 5,
+            ]);
+    }
+
+    public function test_blackbox_user_can_return_active_borrowing(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'stock' => 5,
+            'available_stock' => 3,
+            'condition' => 'baik',
+        ]);
+
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->user->id,
+            'item_id' => $item->id,
+            'quantity' => 2,
+            'status' => 'dipinjam',
+        ]);
+
+        $response = $this->postJson("/api/borrowings/{$borrowing->id}/return");
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'Item returned successfully',
+                'data' => [
+                    'id' => $borrowing->id,
+                    'status' => 'dikembalikan',
+                ],
+            ]);
+
+        $this->assertEquals(5, $item->fresh()->available_stock);
+    }
+
+    public function test_blackbox_user_cannot_return_already_returned_borrowing(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'stock' => 5,
+            'available_stock' => 5,
+            'condition' => 'baik',
+        ]);
+
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->user->id,
+            'item_id' => $item->id,
+            'quantity' => 2,
+            'status' => 'dikembalikan',
+            'return_date' => now(),
+        ]);
+
+        $response = $this->postJson("/api/borrowings/{$borrowing->id}/return");
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'message' => 'Item already returned',
+            ]);
+
+        $this->assertEquals(5, $item->fresh()->available_stock);
+    }
+
+    // ==========================================
+    // 2. WHITE-BOX TESTING (Internal Logic)
+    // ==========================================
+
+    public function test_whitebox_decrease_stock_deducts_model_available_stock_correctly(): void
+    {
+        $item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'stock' => 10,
+            'available_stock' => 10,
+            'condition' => 'baik',
+        ]);
+
+        $item->decreaseStock(4);
+
+        $this->assertEquals(6, $item->fresh()->available_stock);
+    }
+
+    public function test_whitebox_decrease_stock_throws_exception_on_zero_or_negative_quantity(): void
+    {
+        $item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'available_stock' => 5,
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Quantity must be greater than zero.');
+
+        $item->decreaseStock(0);
+    }
+
+    public function test_whitebox_decrease_stock_throws_exception_when_quantity_exceeds_available_stock(): void
+    {
+        $item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'available_stock' => 2,
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot decrease stock below zero.');
+
+        $item->decreaseStock(3);
+    }
+
+    public function test_whitebox_increase_stock_restores_available_stock_correctly(): void
+    {
+        $item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'available_stock' => 3,
+        ]);
+
+        $item->increaseStock(2);
+
+        $this->assertEquals(5, $item->fresh()->available_stock);
+    }
+
+    public function test_whitebox_increase_stock_throws_exception_on_invalid_quantity(): void
+    {
+        $item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'available_stock' => 3,
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Quantity must be greater than zero.');
+
+        $item->increaseStock(-1);
+    }
+
+    public function test_whitebox_transaction_rollback_prevents_partial_commit_on_failure(): void
+    {
+        $item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'available_stock' => 5,
+            'condition' => 'baik',
+        ]);
+
+        $initialStock = $item->available_stock;
+
+        try {
+            DB::transaction(function () use ($item) {
+                $lockedItem = Item::lockForUpdate()->findOrFail($item->id);
+                $lockedItem->decreaseStock(2);
+
+                // Simulate an unexpected error occurring after stock reduction
+                throw new \RuntimeException('Simulated unexpected failure during processing');
+            });
+        } catch (\RuntimeException $e) {
+            // Expected exception
+        }
+
+        // Verify transaction rolled back completely
+        $this->assertEquals($initialStock, $item->fresh()->available_stock);
+    }
+
+    // ==========================================
+    // 3. GREY-BOX TESTING (State & Concurrency Simulation)
+    // ==========================================
+
+    public function test_greybox_simulated_concurrent_borrowings_prevent_negative_stock(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'stock' => 1,
+            'available_stock' => 1,
+            'condition' => 'baik',
+        ]);
+
+        // Request 1: Should succeed and decrease stock from 1 to 0
+        $response1 = $this->postJson('/api/borrowings', [
+            'item_id' => $item->id,
+            'quantity' => 1,
+            'borrow_date' => now()->toDateString(),
+            'due_date' => now()->addDays(2)->toDateString(),
+        ]);
+
+        $response1->assertStatus(201);
+
+        // Request 2: Must be rejected because stock is now 0
+        $response2 = $this->postJson('/api/borrowings', [
+            'item_id' => $item->id,
+            'quantity' => 1,
+            'borrow_date' => now()->toDateString(),
+            'due_date' => now()->addDays(2)->toDateString(),
+        ]);
+
+        $response2->assertStatus(422)
+            ->assertJson([
+                'message' => 'Item is not available in requested quantity',
+                'available_stock' => 0,
+            ]);
+
+        // Database assertion: stock must NOT become -1
+        $this->assertDatabaseHas('items', [
+            'id' => $item->id,
+            'available_stock' => 0,
+        ]);
+
+        // Only one borrowing should exist in the database
+        $this->assertEquals(1, Borrowing::where('item_id', $item->id)->count());
+    }
+
+    public function test_greybox_simulated_double_return_does_not_inflate_stock(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'stock' => 5,
+            'available_stock' => 3,
+            'condition' => 'baik',
+        ]);
+
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->user->id,
+            'item_id' => $item->id,
+            'quantity' => 2,
+            'status' => 'dipinjam',
+        ]);
+
+        // First return attempt: succeeds
+        $res1 = $this->postJson("/api/borrowings/{$borrowing->id}/return");
+        $res1->assertStatus(200);
+
+        // Immediate second return attempt: must be rejected
+        $res2 = $this->postJson("/api/borrowings/{$borrowing->id}/return");
+        $res2->assertStatus(422);
+
+        // Database assertion: stock should be 5, not inflated to 7
+        $this->assertDatabaseHas('items', [
+            'id' => $item->id,
+            'available_stock' => 5,
+        ]);
+
+        $this->assertDatabaseHas('borrowings', [
+            'id' => $borrowing->id,
+            'status' => 'dikembalikan',
+        ]);
+    }
+
+    public function test_greybox_database_state_consistency_through_full_borrow_and_return_cycle(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'stock' => 10,
+            'available_stock' => 10,
+            'condition' => 'baik',
+        ]);
+
+        // 1. Borrow 4 items
+        $borrowResponse = $this->postJson('/api/borrowings', [
+            'item_id' => $item->id,
+            'quantity' => 4,
+            'borrow_date' => now()->toDateString(),
+            'due_date' => now()->addDays(5)->toDateString(),
+        ]);
+
+        $borrowResponse->assertStatus(201);
+        $borrowingId = $borrowResponse->json('data.id');
+
+        $this->assertDatabaseHas('items', [
+            'id' => $item->id,
+            'available_stock' => 6,
+        ]);
+
+        $this->assertDatabaseHas('borrowings', [
+            'id' => $borrowingId,
+            'status' => 'dipinjam',
+            'quantity' => 4,
+        ]);
+
+        // 2. Return the 4 items
+        $returnResponse = $this->postJson("/api/borrowings/{$borrowingId}/return");
+        $returnResponse->assertStatus(200);
+
+        $this->assertDatabaseHas('items', [
+            'id' => $item->id,
+            'available_stock' => 10,
+        ]);
+
+        $this->assertDatabaseHas('borrowings', [
+            'id' => $borrowingId,
+            'status' => 'dikembalikan',
+        ]);
+    }
+}


### PR DESCRIPTION
## Description
Resolves race conditions and transaction atomicity issues during item borrowing and returns (Bug **B2** in Sprint 1).

## Changes Made
1. **`BorrowingController::store()`**:
   - Wrapped borrowing record creation and stock reduction inside `DB::transaction()`.
   - Utilized pessimistic row-level locking via `Item::lockForUpdate()->findOrFail($validated['item_id'])` to prevent concurrent overselling.
   - Evaluated `$item->isAvailable($quantity)` within the locked transaction boundary.
2. **`BorrowingController::return()` & `Borrowing::processReturn()`**:
   - Wrapped return processing in `DB::transaction()` with pessimistic locking (`Borrowing::lockForUpdate()`, `Item::lockForUpdate()`).
   - Guarded against concurrent duplicate return requests.
3. **`Item.php` Guard Clauses**:
   - Added validation in `Item::decreaseStock()` and `increaseStock()` to ensure quantity is positive and prevent stock from falling below zero.
4. **`ItemFactory.php` Default State**:
   - Normalized default condition to `'baik'` with explicit `damaged()` and `lost()` state modifiers.
5. **Testing**:
   - Added `tests/Feature/BorrowingStockRaceConditionTest.php` with 14 comprehensive tests covering Black-Box, White-Box, and Grey-Box methodologies (100% passing).

Closes #13
