### PR TITLE
fix(borrowing): eliminate N+1 query and optimize overdue status update on index (B5)

### DIFF
--- a/app/Console/Commands/CheckOverdueBorrowings.php
+++ b/app/Console/Commands/CheckOverdueBorrowings.php
@@ -21,7 +21,14 @@ class CheckOverdueBorrowings extends Command
      *
      * @var string
      */
-    protected $description = 'Check for overdue borrowings and send notifications';
+    protected $description = 'Check for overdue borrowings, send notifications, and update status to terlambat';
+
+    /**
+     * The command aliases.
+     *
+     * @var array<int, string>
+     */
+    protected $aliases = ['borrowings:update-overdue'];
 
     /**
      * Execute the console command.
@@ -48,13 +55,19 @@ class CheckOverdueBorrowings extends Command
                 );
                 
                 $totalNotified++;
-                $this->warn("Overdue notification sent to {$borrowing->user->name} for borrowing {$borrowing->code} ({$daysOverdue} days late)");
+                $this->warn("Overdue notification sent to {$borrowing->user->name} for borrowing {$borrowing->borrow_code} ({$daysOverdue} days late)");
             } catch (\Exception $e) {
-                $this->error("Failed to send notification for borrowing {$borrowing->code}: {$e->getMessage()}");
+                $this->error("Failed to send notification for borrowing {$borrowing->borrow_code}: {$e->getMessage()}");
             }
         }
 
+        // Batch update status to 'terlambat'
+        $updatedCount = Borrowing::where('status', 'dipinjam')
+            ->where('due_date', '<', Carbon::today())
+            ->update(['status' => 'terlambat']);
+
         $this->info("Total overdue notifications sent: {$totalNotified}");
+        $this->info("Total borrowings updated to 'terlambat': {$updatedCount}");
         
         return Command::SUCCESS;
     }

--- a/app/Http/Controllers/Api/BorrowingController.php
+++ b/app/Http/Controllers/Api/BorrowingController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Models\Borrowing;
 use App\Models\Item;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
@@ -63,9 +64,14 @@ class BorrowingController extends Controller
         }
 
         // Filter overdue only
-        if ($request->has('overdue') && $request->overdue === 'true') {
-            $query->where('status', 'dipinjam')
-                  ->where('due_date', '<', now());
+        if ($request->has('overdue') && ($request->overdue === 'true' || $request->overdue === true || $request->overdue === '1' || $request->overdue === 1)) {
+            $query->where(function ($q) {
+                $q->where('status', 'terlambat')
+                  ->orWhere(function ($sub) {
+                      $sub->where('status', 'dipinjam')
+                          ->where('due_date', '<', Carbon::today());
+                  });
+            });
         }
 
         // Sorting
@@ -79,10 +85,10 @@ class BorrowingController extends Controller
             $query->latest();
         }
 
-        // Update overdue status
-        $query->get()->each(function ($borrowing) {
-            $borrowing->updateOverdueStatus();
-        });
+        // Batch update overdue status atomically without loading all records into memory (eliminating N+1 query)
+        Borrowing::where('status', 'dipinjam')
+            ->where('due_date', '<', Carbon::today())
+            ->update(['status' => 'terlambat']);
 
         $borrowings = $query->paginate($request->per_page ?? 15);
 

--- a/tests/Feature/BorrowingIndexNPlusOneTest.php
+++ b/tests/Feature/BorrowingIndexNPlusOneTest.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Borrowing;
+use App\Models\Category;
+use App\Models\Item;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class BorrowingIndexNPlusOneTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+    private User $staff;
+    private Category $category;
+    private Item $item;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create([
+            'role' => 'admin',
+        ]);
+
+        $this->staff = User::factory()->create([
+            'role' => 'staff',
+        ]);
+
+        $this->category = Category::factory()->create();
+
+        $this->item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'stock' => 20,
+            'available_stock' => 20,
+            'condition' => 'baik',
+        ]);
+    }
+
+    // ==========================================
+    // 1. BLACK-BOX TESTING (API & Contract)
+    // ==========================================
+
+    public function test_blackbox_user_can_paginate_borrowings_normally(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        Borrowing::factory()->count(10)->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+        ]);
+
+        $response = $this->getJson('/api/borrowings?per_page=5');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'current_page',
+                'data' => [
+                    '*' => [
+                        'id',
+                        'borrow_code',
+                        'status',
+                        'user',
+                        'item',
+                    ],
+                ],
+                'per_page',
+                'total',
+            ]);
+
+        $this->assertEquals(5, count($response->json('data')));
+        $this->assertEquals(10, $response->json('total'));
+    }
+
+    public function test_blackbox_overdue_filter_returns_all_overdue_borrowings(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        // 1 overdue borrowing (due yesterday)
+        $overdue = Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'status' => 'dipinjam',
+            'borrow_date' => Carbon::today()->subDays(5)->toDateString(),
+            'due_date' => Carbon::today()->subDays(1)->toDateString(),
+        ]);
+
+        // 1 on-time active borrowing (due in 5 days)
+        $active = Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'status' => 'dipinjam',
+            'borrow_date' => Carbon::today()->toDateString(),
+            'due_date' => Carbon::today()->addDays(5)->toDateString(),
+        ]);
+
+        $response = $this->getJson('/api/borrowings?overdue=true');
+
+        $response->assertStatus(200);
+        $ids = collect($response->json('data'))->pluck('id')->all();
+
+        $this->assertContains($overdue->id, $ids);
+        $this->assertNotContains($active->id, $ids);
+    }
+
+    public function test_blackbox_pagination_respects_custom_per_page(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        Borrowing::factory()->count(8)->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+        ]);
+
+        $response = $this->getJson('/api/borrowings?per_page=3');
+
+        $response->assertStatus(200);
+        $this->assertEquals(3, count($response->json('data')));
+        $this->assertEquals(8, $response->json('total'));
+        $this->assertEquals(3, $response->json('last_page'));
+    }
+
+    // ==========================================
+    // 2. WHITE-BOX TESTING (Query Performance & Count)
+    // ==========================================
+
+    public function test_whitebox_index_query_count_is_constant_regardless_of_overdue_items(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        // Setup: Create 15 overdue borrowings
+        for ($i = 0; $i < 15; $i++) {
+            Borrowing::factory()->create([
+                'item_id' => $this->item->id,
+                'user_id' => $this->staff->id,
+                'status' => 'dipinjam',
+                'borrow_date' => Carbon::today()->subDays(10)->toDateString(),
+                'due_date' => Carbon::today()->subDays(2)->toDateString(),
+            ]);
+        }
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $response = $this->getJson('/api/borrowings?per_page=15');
+        $response->assertStatus(200);
+
+        $queries = DB::getQueryLog();
+        DB::disableQueryLog();
+
+        // Check the queries executed:
+        // Before the fix, there was 1 query to get all items + 15 individual UPDATE queries (N+1) + paginate queries
+        // With batch update, there should be exactly ONE update query for all overdue records, NOT 15 updates!
+        $updateQueries = array_filter($queries, function ($q) {
+            return stripos($q['query'], 'update') !== false && stripos($q['query'], 'borrowings') !== false;
+        });
+
+        // Assert exactly 1 batch update query was executed (O(1) instead of O(N))
+        $this->assertCount(1, $updateQueries, 'Expected exactly 1 atomic batch UPDATE query, found ' . count($updateQueries));
+
+        // Ensure total queries is small and constant (batch update + count + select limit + eager loads)
+        $this->assertLessThanOrEqual(6, count($queries), 'Total queries exceeded threshold, possible query leak.');
+    }
+
+    public function test_whitebox_artisan_command_updates_overdue_borrowings(): void
+    {
+        Borrowing::factory()->count(3)->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'status' => 'dipinjam',
+            'borrow_date' => Carbon::today()->subDays(7)->toDateString(),
+            'due_date' => Carbon::today()->subDays(1)->toDateString(),
+        ]);
+
+        // Test check-overdue signature
+        $this->artisan('borrowings:check-overdue')
+            ->expectsOutputToContain('Total borrowings updated to \'terlambat\': 3')
+            ->assertSuccessful();
+
+        $this->assertEquals(0, Borrowing::where('status', 'dipinjam')->where('due_date', '<', Carbon::today())->count());
+        $this->assertEquals(3, Borrowing::where('status', 'terlambat')->count());
+
+        // Test alias update-overdue signature
+        Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'status' => 'dipinjam',
+            'borrow_date' => Carbon::today()->subDays(5)->toDateString(),
+            'due_date' => Carbon::today()->subDays(2)->toDateString(),
+        ]);
+
+        $this->artisan('borrowings:update-overdue')
+            ->expectsOutputToContain('Total borrowings updated to \'terlambat\': 1')
+            ->assertSuccessful();
+    }
+
+    // ==========================================
+    // 3. GREY-BOX TESTING (Database State & Transition Integrity)
+    // ==========================================
+
+    public function test_greybox_batch_overdue_update_only_affects_eligible_records(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        // 1. Eligible overdue borrowing (status = dipinjam, past due)
+        $eligible = Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'status' => 'dipinjam',
+            'borrow_date' => Carbon::today()->subDays(10)->toDateString(),
+            'due_date' => Carbon::today()->subDays(3)->toDateString(),
+        ]);
+
+        // 2. Active non-overdue borrowing (status = dipinjam, future due date)
+        $notOverdue = Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'status' => 'dipinjam',
+            'borrow_date' => Carbon::today()->toDateString(),
+            'due_date' => Carbon::today()->addDays(3)->toDateString(),
+        ]);
+
+        // 3. Already returned borrowing (status = dikembalikan, past due date)
+        $returned = Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'status' => 'dikembalikan',
+            'borrow_date' => Carbon::today()->subDays(10)->toDateString(),
+            'due_date' => Carbon::today()->subDays(3)->toDateString(),
+            'return_date' => Carbon::today()->subDays(2)->toDateString(),
+        ]);
+
+        // Trigger index action
+        $response = $this->getJson('/api/borrowings');
+        $response->assertStatus(200);
+
+        // Direct database assertions
+        $this->assertDatabaseHas('borrowings', [
+            'id' => $eligible->id,
+            'status' => 'terlambat',
+        ]);
+
+        $this->assertDatabaseHas('borrowings', [
+            'id' => $notOverdue->id,
+            'status' => 'dipinjam',
+        ]);
+
+        $this->assertDatabaseHas('borrowings', [
+            'id' => $returned->id,
+            'status' => 'dikembalikan',
+        ]);
+    }
+}


### PR DESCRIPTION
## Description
Eliminates the N+1 query problem and memory exhaustion risk during borrowing listing, and optimizes the overdue check and filtering (Bug **B5** in Sprint 1).

## Changes Made
1. **`BorrowingController::index()`**:
   - Replaced `$query->get()->each(fn ($b) => $b->updateOverdueStatus())` with a single atomic database batch update:
     ```php
     Borrowing::where('status', 'dipinjam')
         ->where('due_date', '<', Carbon::today())
         ->update(['status' => 'terlambat']);
     ```
   - Corrected the `overdue=true` query filter to inclusively match both records with status `'terlambat'` and active records past their due date.
2. **`CheckOverdueBorrowings.php`**:
   - Added alias `borrowings:update-overdue`.
   - Added batch status update to `'terlambat'` so CLI/scheduled executions synchronize database status alongside sending user notifications.
3. **Automated Testing (`BorrowingIndexNPlusOneTest.php`)**:
   - Added 6 tests covering Black-Box, White-Box, and Grey-Box testing:
     - Verified query count remains constant ($O(1)$) regardless of the number of overdue records via query log assertions.
     - Verified Artisan command executions for both signatures (`borrowings:check-overdue` and `borrowings:update-overdue`).
     - Verified direct database state assertions for overdue transitions.

Closes #15
