### PR TITLE
fix(borrowing): complete approval and rejection flow with schema sync (B4, B7, B8)

### DIFF
--- a/app/Http/Controllers/Api/BorrowingController.php
+++ b/app/Http/Controllers/Api/BorrowingController.php
@@ -214,15 +214,117 @@ class BorrowingController extends Controller
             ], 403);
         }
 
-        $borrowing->approved_by = $request->user()->id;
-        $borrowing->save();
+        // Check if already approved or processed
+        if ($borrowing->approved_by !== null || in_array($borrowing->status, ['approved', 'dipinjam', 'dikembalikan', 'terlambat', 'ditolak', 'rejected'])) {
+            return response()->json([
+                'message' => 'Peminjaman sudah diproses atau sudah disetujui.',
+            ], 400);
+        }
 
-        $borrowing->load(['user', 'item', 'approver']);
+        $result = DB::transaction(function () use ($request, $borrowing) {
+            /** @var Borrowing $lockedBorrowing */
+            $lockedBorrowing = Borrowing::lockForUpdate()->findOrFail($borrowing->id);
 
-        return response()->json([
-            'message' => 'Borrowing approved successfully',
-            'data' => $borrowing,
-        ]);
+            if ($lockedBorrowing->approved_by !== null || in_array($lockedBorrowing->status, ['approved', 'dipinjam', 'dikembalikan', 'terlambat', 'ditolak', 'rejected'])) {
+                return [
+                    'status' => 400,
+                    'payload' => [
+                        'message' => 'Peminjaman sudah diproses atau sudah disetujui.',
+                    ],
+                ];
+            }
+
+            /** @var Item $item */
+            $item = Item::lockForUpdate()->findOrFail($lockedBorrowing->item_id);
+
+            // If status is pending, deduct stock upon approval
+            if ($lockedBorrowing->status === 'pending') {
+                if (!$item->isAvailable($lockedBorrowing->quantity)) {
+                    return [
+                        'status' => 422,
+                        'payload' => [
+                            'message' => 'Stok barang tidak mencukupi untuk disetujui.',
+                            'available_stock' => $item->available_stock,
+                        ],
+                    ];
+                }
+
+                $item->decreaseStock($lockedBorrowing->quantity);
+            }
+
+            $lockedBorrowing->status = 'dipinjam';
+            $lockedBorrowing->approved_by = $request->user()->id;
+            $lockedBorrowing->approved_at = now();
+            $lockedBorrowing->save();
+
+            $lockedBorrowing->load(['user', 'item', 'approver']);
+
+            return [
+                'status' => 200,
+                'payload' => [
+                    'message' => 'Borrowing approved successfully',
+                    'data' => $lockedBorrowing,
+                ],
+            ];
+        });
+
+        if ($result['status'] === 200) {
+            try {
+                \App\Jobs\SendBorrowingNotification::dispatch($result['payload']['data'], 'approved');
+            } catch (\Throwable $e) {
+                logger()->warning('Failed to dispatch SendBorrowingNotification: ' . $e->getMessage());
+            }
+        }
+
+        return response()->json($result['payload'], $result['status']);
+    }
+
+    /**
+     * Reject borrowing (admin only)
+     */
+    public function reject(Request $request, Borrowing $borrowing)
+    {
+        if (!$request->user()->isAdmin()) {
+            return response()->json([
+                'message' => 'Unauthorized. Admin access required.',
+            ], 403);
+        }
+
+        // Check if already processed
+        if ($borrowing->approved_by !== null || in_array($borrowing->status, ['approved', 'dipinjam', 'dikembalikan', 'terlambat', 'ditolak', 'rejected'])) {
+            return response()->json([
+                'message' => 'Peminjaman sudah diproses.',
+            ], 400);
+        }
+
+        $result = DB::transaction(function () use ($borrowing) {
+            /** @var Borrowing $lockedBorrowing */
+            $lockedBorrowing = Borrowing::lockForUpdate()->findOrFail($borrowing->id);
+
+            if ($lockedBorrowing->approved_by !== null || in_array($lockedBorrowing->status, ['approved', 'dipinjam', 'dikembalikan', 'terlambat', 'ditolak', 'rejected'])) {
+                return [
+                    'status' => 400,
+                    'payload' => [
+                        'message' => 'Peminjaman sudah diproses.',
+                    ],
+                ];
+            }
+
+            $lockedBorrowing->status = 'rejected';
+            $lockedBorrowing->save();
+
+            $lockedBorrowing->load(['user', 'item', 'approver']);
+
+            return [
+                'status' => 200,
+                'payload' => [
+                    'message' => 'Borrowing rejected successfully',
+                    'data' => $lockedBorrowing,
+                ],
+            ];
+        });
+
+        return response()->json($result['payload'], $result['status']);
     }
 
     /**

--- a/app/Models/Borrowing.php
+++ b/app/Models/Borrowing.php
@@ -29,6 +29,7 @@ class Borrowing extends Model
         'status',
         'notes',
         'approved_by',
+        'approved_at',
     ];
 
     /**
@@ -40,6 +41,7 @@ class Borrowing extends Model
         'borrow_date' => 'datetime',
         'due_date' => 'datetime',
         'return_date' => 'datetime',
+        'approved_at' => 'datetime',
         'quantity' => 'integer',
     ];
 

--- a/database/migrations/2026_01_08_000001_update_borrowings_status_and_add_approved_at.php
+++ b/database/migrations/2026_01_08_000001_update_borrowings_status_and_add_approved_at.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('borrowings', function (Blueprint $table) {
+            if (!Schema::hasColumn('borrowings', 'approved_at')) {
+                $table->timestamp('approved_at')->nullable()->after('approved_by');
+            }
+            if (DB::getDriverName() === 'sqlite') {
+                $table->string('status')->default('pending')->change();
+            }
+        });
+
+        if (DB::getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE borrowings MODIFY COLUMN status ENUM('pending', 'dipinjam', 'dikembalikan', 'terlambat', 'ditolak', 'rejected', 'approved') NOT NULL DEFAULT 'pending'");
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE borrowings MODIFY COLUMN status ENUM('dipinjam', 'dikembalikan', 'terlambat') NOT NULL DEFAULT 'dipinjam'");
+        }
+
+        Schema::table('borrowings', function (Blueprint $table) {
+            if (Schema::hasColumn('borrowings', 'approved_at')) {
+                $table->dropColumn('approved_at');
+            }
+            if (DB::getDriverName() === 'sqlite') {
+                $table->string('status')->default('dipinjam')->change();
+            }
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -53,7 +53,8 @@ Route::prefix('v1')->group(function () {
         // Borrowings
         Route::apiResource('borrowings', BorrowingController::class);
         Route::post('/borrowings/{borrowing}/return', [BorrowingController::class, 'return']);
-        Route::post('/borrowings/{borrowing}/approve', [BorrowingController::class, 'approve']);
+        Route::match(['post', 'put'], '/borrowings/{borrowing}/approve', [BorrowingController::class, 'approve']);
+        Route::match(['post', 'put'], '/borrowings/{borrowing}/reject', [BorrowingController::class, 'reject']);
         Route::post('/borrowings/{borrowing}/extend', [BorrowingController::class, 'extend']);
         Route::get('/borrowings/my/list', [BorrowingController::class, 'myBorrowings']);
 
@@ -115,7 +116,8 @@ Route::middleware(['auth:sanctum', 'throttle:60,1'])->group(function () {
     Route::get('/items/search-suggestions', [ItemController::class, 'searchSuggestions']);
     Route::apiResource('borrowings', BorrowingController::class);
     Route::post('/borrowings/{borrowing}/return', [BorrowingController::class, 'return']);
-    Route::post('/borrowings/{borrowing}/approve', [BorrowingController::class, 'approve']);
+    Route::match(['post', 'put'], '/borrowings/{borrowing}/approve', [BorrowingController::class, 'approve']);
+    Route::match(['post', 'put'], '/borrowings/{borrowing}/reject', [BorrowingController::class, 'reject']);
     Route::post('/borrowings/{borrowing}/extend', [BorrowingController::class, 'extend']);
     Route::get('/borrowings/my/list', [BorrowingController::class, 'myBorrowings']);
     Route::prefix('reports')->group(function () {

--- a/tests/Feature/BorrowingApprovalFlowTest.php
+++ b/tests/Feature/BorrowingApprovalFlowTest.php
@@ -1,0 +1,334 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\SendBorrowingNotification;
+use App\Models\Borrowing;
+use App\Models\Category;
+use App\Models\Item;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class BorrowingApprovalFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+    private User $staff;
+    private Category $category;
+    private Item $item;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create([
+            'role' => 'admin',
+        ]);
+
+        $this->staff = User::factory()->create([
+            'role' => 'staff',
+        ]);
+
+        $this->category = Category::factory()->create();
+
+        $this->item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'stock' => 10,
+            'available_stock' => 10,
+            'condition' => 'baik',
+        ]);
+    }
+
+    // ==========================================
+    // 1. BLACK-BOX TESTING (API & Authorization)
+    // ==========================================
+
+    public function test_blackbox_admin_can_approve_pending_borrowing(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        $borrowing = Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'quantity' => 2,
+            'status' => 'pending',
+            'approved_by' => null,
+            'approved_at' => null,
+        ]);
+
+        $response = $this->postJson("/api/borrowings/{$borrowing->id}/approve");
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'Borrowing approved successfully',
+                'data' => [
+                    'id' => $borrowing->id,
+                    'status' => 'dipinjam',
+                    'approved_by' => $this->admin->id,
+                ],
+            ]);
+
+        $this->assertNotNull($response->json('data.approved_at'));
+    }
+
+    public function test_blackbox_staff_cannot_approve_borrowing(): void
+    {
+        Sanctum::actingAs($this->staff);
+
+        $borrowing = Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'status' => 'pending',
+        ]);
+
+        $response = $this->postJson("/api/borrowings/{$borrowing->id}/approve");
+
+        $response->assertStatus(403)
+            ->assertJson([
+                'message' => 'Unauthorized. Admin access required.',
+            ]);
+    }
+
+    public function test_blackbox_cannot_approve_already_approved_borrowing(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        $borrowing = Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'status' => 'approved',
+            'approved_by' => $this->admin->id,
+            'approved_at' => now(),
+        ]);
+
+        // Using PUT for compatibility
+        $response = $this->putJson("/api/borrowings/{$borrowing->id}/approve");
+
+        $response->assertStatus(400);
+    }
+
+    public function test_blackbox_admin_can_reject_pending_borrowing(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        $borrowing = Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'status' => 'pending',
+        ]);
+
+        $response = $this->putJson("/api/borrowings/{$borrowing->id}/reject");
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'Borrowing rejected successfully',
+                'data' => [
+                    'id' => $borrowing->id,
+                    'status' => 'rejected',
+                ],
+            ]);
+    }
+
+    public function test_blackbox_staff_cannot_reject_borrowing(): void
+    {
+        Sanctum::actingAs($this->staff);
+
+        $borrowing = Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'status' => 'pending',
+        ]);
+
+        $response = $this->postJson("/api/borrowings/{$borrowing->id}/reject");
+
+        $response->assertStatus(403);
+    }
+
+    public function test_blackbox_cannot_reject_already_processed_borrowing(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        $borrowing = Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'status' => 'dipinjam',
+            'approved_by' => $this->admin->id,
+        ]);
+
+        $response = $this->postJson("/api/borrowings/{$borrowing->id}/reject");
+
+        $response->assertStatus(400);
+    }
+
+    // ==========================================
+    // 2. WHITE-BOX TESTING (Internal Logic & Stock)
+    // ==========================================
+
+    public function test_whitebox_approval_deducts_item_stock_within_transaction(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        $borrowing = Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'quantity' => 4,
+            'status' => 'pending',
+        ]);
+
+        $initialStock = $this->item->available_stock; // 10
+
+        $response = $this->postJson("/api/borrowings/{$borrowing->id}/approve");
+        $response->assertStatus(200);
+
+        $this->assertEquals($initialStock - 4, $this->item->fresh()->available_stock); // 6
+    }
+
+    public function test_whitebox_approval_fails_safely_if_stock_insufficient(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        // Reduce available stock to 1
+        $this->item->update(['available_stock' => 1]);
+
+        $borrowing = Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'quantity' => 3, // Needs 3, only 1 available
+            'status' => 'pending',
+        ]);
+
+        $response = $this->postJson("/api/borrowings/{$borrowing->id}/approve");
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'message' => 'Stok barang tidak mencukupi untuk disetujui.',
+                'available_stock' => 1,
+            ]);
+
+        // State integrity: borrowing remains pending and stock untouched
+        $this->assertEquals('pending', $borrowing->fresh()->status);
+        $this->assertNull($borrowing->fresh()->approved_by);
+        $this->assertEquals(1, $this->item->fresh()->available_stock);
+    }
+
+    public function test_whitebox_rejection_does_not_modify_item_stock(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        $borrowing = Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'quantity' => 3,
+            'status' => 'pending',
+        ]);
+
+        $stockBefore = $this->item->available_stock;
+
+        $response = $this->postJson("/api/borrowings/{$borrowing->id}/reject");
+        $response->assertStatus(200);
+
+        $this->assertEquals($stockBefore, $this->item->fresh()->available_stock);
+    }
+
+    // ==========================================
+    // 3. GREY-BOX TESTING (DB State & Events)
+    // ==========================================
+
+    public function test_greybox_database_state_transitions_for_approval_lifecycle(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        $borrowing = Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'quantity' => 2,
+            'status' => 'pending',
+            'approved_by' => null,
+            'approved_at' => null,
+        ]);
+
+        $this->assertDatabaseHas('borrowings', [
+            'id' => $borrowing->id,
+            'status' => 'pending',
+            'approved_by' => null,
+        ]);
+
+        $response = $this->postJson("/api/borrowings/{$borrowing->id}/approve");
+        $response->assertStatus(200);
+
+        $this->assertDatabaseHas('borrowings', [
+            'id' => $borrowing->id,
+            'status' => 'dipinjam',
+            'approved_by' => $this->admin->id,
+        ]);
+
+        $freshBorrowing = Borrowing::find($borrowing->id);
+        $this->assertNotNull($freshBorrowing->approved_at);
+    }
+
+    public function test_greybox_notification_dispatched_upon_approval(): void
+    {
+        Queue::fake();
+        Sanctum::actingAs($this->admin);
+
+        $borrowing = Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'quantity' => 1,
+            'status' => 'pending',
+        ]);
+
+        $response = $this->postJson("/api/borrowings/{$borrowing->id}/approve");
+        $response->assertStatus(200);
+
+        Queue::assertPushed(SendBorrowingNotification::class, function ($job) use ($borrowing) {
+            return $job->borrowing->id === $borrowing->id && $job->notificationType === 'approved';
+        });
+    }
+
+    public function test_greybox_both_post_and_put_work_for_approve_and_reject(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        // Test POST approve
+        $b1 = Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'quantity' => 1,
+            'status' => 'pending',
+        ]);
+        $this->postJson("/api/borrowings/{$b1->id}/approve")->assertStatus(200);
+
+        // Test PUT approve
+        $b2 = Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'quantity' => 1,
+            'status' => 'pending',
+        ]);
+        $this->putJson("/api/borrowings/{$b2->id}/approve")->assertStatus(200);
+
+        // Test POST reject
+        $b3 = Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'quantity' => 1,
+            'status' => 'pending',
+        ]);
+        $this->postJson("/api/borrowings/{$b3->id}/reject")->assertStatus(200);
+
+        // Test PUT reject
+        $b4 = Borrowing::factory()->create([
+            'item_id' => $this->item->id,
+            'user_id' => $this->staff->id,
+            'quantity' => 1,
+            'status' => 'pending',
+        ]);
+        $this->putJson("/api/borrowings/{$b4->id}/reject")->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Description
Completes the approval and rejection lifecycle, adds atomic stock deduction upon approval, prevents double approval/processing, and synchronizes the database schema for statuses and timestamps (Bugs **B4**, **B7**, and **B8**).

## Changes Made
1. **Database Migration (`2026_01_08_000001_update_borrowings_status_and_add_approved_at.php`)**:
   - Added nullable `approved_at` timestamp column to `borrowings` table.
   - Extended `status` enum to support `'pending'`, `'dipinjam'`, `'dikembalikan'`, `'terlambat'`, `'ditolak'`, `'rejected'`, `'approved'`.
2. **`Borrowing` Model**:
   - Added `approved_at` to `$fillable` and cast as `datetime`.
3. **`BorrowingController::approve()`**:
   - Restricted to Admin.
   - Guarded against re-approval of already processed/approved borrowings (returns HTTP 400).
   - Applied `DB::transaction()` and pessimistic row lock (`Item::lockForUpdate()`) to verify available stock and deduct stock atomically.
   - Updated status to `'dipinjam'`, assigned `approved_by` and `approved_at`.
   - Dispatched `SendBorrowingNotification` with type `'approved'`.
4. **`BorrowingController::reject()` & Routes**:
   - Added `reject()` method: validates admin, rejects pending requests without stock modification.
   - Registered `POST|PUT /api/borrowings/{borrowing}/approve` and `POST|PUT /api/borrowings/{borrowing}/reject` across API routes for backwards compatibility.
5. **Testing (`BorrowingApprovalFlowTest.php`)**:
   - Added 12 automated unit & feature tests covering Black-Box, White-Box, and Grey-Box testing methodologies (100% passing).

Closes #17
