### PR TITLE
refactor(borrowing): use StoreBorrowingRequest and UpdateBorrowingRequest in BorrowingController (R5, R6)

### DIFF
--- a/app/Http/Controllers/Api/BorrowingController.php
+++ b/app/Http/Controllers/Api/BorrowingController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers\Api;
 
 use App\Exceptions\BorrowingException;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreBorrowingRequest;
+use App\Http\Requests\UpdateBorrowingRequest;
 use App\Models\Borrowing;
 use App\Services\BorrowingService;
 use Carbon\Carbon;
@@ -103,18 +105,10 @@ class BorrowingController extends Controller
     /**
      * Store a newly created borrowing
      */
-    public function store(Request $request)
+    public function store(StoreBorrowingRequest $request)
     {
-        $validated = $request->validate([
-            'item_id' => 'required|exists:items,id',
-            'quantity' => 'required|integer|min:1',
-            'borrow_date' => 'required|date',
-            'due_date' => 'required|date|after:borrow_date',
-            'notes' => 'nullable|string',
-        ]);
-
         try {
-            $borrowing = $this->borrowingService->createBorrowing($validated, $request->user()->id);
+            $borrowing = $this->borrowingService->createBorrowing($request->validated(), $request->user()->id);
 
             return response()->json([
                 'message' => 'Borrowing created successfully',
@@ -212,7 +206,7 @@ class BorrowingController extends Controller
     /**
      * Update the specified borrowing
      */
-    public function update(Request $request, Borrowing $borrowing)
+    public function update(UpdateBorrowingRequest $request, Borrowing $borrowing)
     {
         if ($borrowing->status === 'dikembalikan') {
             return response()->json([
@@ -220,12 +214,7 @@ class BorrowingController extends Controller
             ], 422);
         }
 
-        $validated = $request->validate([
-            'due_date' => 'sometimes|date|after:borrow_date',
-            'notes' => 'nullable|string',
-        ]);
-
-        $borrowing->update($validated);
+        $borrowing->update($request->validated());
         $borrowing->load(['user', 'item', 'approver']);
 
         return response()->json([

--- a/app/Http/Requests/StoreBorrowingRequest.php
+++ b/app/Http/Requests/StoreBorrowingRequest.php
@@ -51,21 +51,4 @@ class StoreBorrowingRequest extends FormRequest
             'notes.max' => 'Catatan maksimal 500 karakter',
         ];
     }
-
-    /**
-     * Configure the validator instance.
-     */
-    public function withValidator($validator)
-    {
-        $validator->after(function ($validator) {
-            $item = \App\Models\Item::find($this->item_id);
-            
-            if ($item && $this->quantity > $item->available_stock) {
-                $validator->errors()->add(
-                    'quantity',
-                    "Stok tidak mencukupi. Stok tersedia: {$item->available_stock}"
-                );
-            }
-        });
-    }
 }

--- a/app/Http/Requests/UpdateBorrowingRequest.php
+++ b/app/Http/Requests/UpdateBorrowingRequest.php
@@ -15,6 +15,25 @@ class UpdateBorrowingRequest extends FormRequest
     }
 
     /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        $borrowing = $this->route('borrowing');
+        if ($borrowing && !$this->has('borrow_date')) {
+            $borrowDate = $borrowing instanceof \App\Models\Borrowing
+                ? $borrowing->borrow_date
+                : \App\Models\Borrowing::find($borrowing)?->borrow_date;
+
+            if ($borrowDate) {
+                $this->merge([
+                    'borrow_date' => \Carbon\Carbon::parse($borrowDate)->toDateString(),
+                ]);
+            }
+        }
+    }
+
+    /**
      * Get the validation rules that apply to the request.
      *
      * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>

--- a/tests/Feature/BorrowingFormRequestTest.php
+++ b/tests/Feature/BorrowingFormRequestTest.php
@@ -1,0 +1,339 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Requests\StoreBorrowingRequest;
+use App\Http\Requests\UpdateBorrowingRequest;
+use App\Models\Borrowing;
+use App\Models\Category;
+use App\Models\Item;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Validator;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class BorrowingFormRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $admin;
+    protected User $staff;
+    protected Category $category;
+    protected Item $item;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create([
+            'role' => 'admin',
+            'email' => 'admin@example.com',
+        ]);
+
+        $this->staff = User::factory()->create([
+            'role' => 'staff',
+            'email' => 'staff@example.com',
+        ]);
+
+        $this->category = Category::factory()->create([
+            'name' => 'Alat Elektronik',
+        ]);
+
+        $this->item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'name' => 'Kamera DSLR Canon',
+            'code' => 'ITM-2026-0099',
+            'stock' => 5,
+            'available_stock' => 5,
+            'condition' => 'baik',
+        ]);
+    }
+
+    /* =========================================================================
+     * ⚪ WHITE-BOX TESTING (Rules, Messages & PrepareForValidation)
+     * ========================================================================= */
+
+    public function test_whitebox_store_borrowing_request_rules_and_custom_messages(): void
+    {
+        $request = new StoreBorrowingRequest();
+        $rules = $request->rules();
+        $messages = $request->messages();
+
+        $this->assertTrue($request->authorize());
+
+        // Validate required fields
+        $this->assertArrayHasKey('item_id', $rules);
+        $this->assertArrayHasKey('quantity', $rules);
+        $this->assertArrayHasKey('borrow_date', $rules);
+        $this->assertArrayHasKey('due_date', $rules);
+        $this->assertArrayHasKey('notes', $rules);
+
+        // Validate error messages
+        $validator = Validator::make([], $rules, $messages);
+        $this->assertTrue($validator->fails());
+
+        $errors = $validator->errors()->messages();
+        $this->assertContains('Barang wajib dipilih', $errors['item_id'] ?? []);
+        $this->assertContains('Jumlah wajib diisi', $errors['quantity'] ?? []);
+        $this->assertContains('Tanggal pinjam wajib diisi', $errors['borrow_date'] ?? []);
+        $this->assertContains('Tanggal kembali wajib diisi', $errors['due_date'] ?? []);
+    }
+
+    public function test_whitebox_store_borrowing_request_validates_quantity_and_dates(): void
+    {
+        $request = new StoreBorrowingRequest();
+        $rules = $request->rules();
+        $messages = $request->messages();
+
+        // Quantity < 1
+        $validator = Validator::make([
+            'item_id' => $this->item->id,
+            'quantity' => 0,
+            'borrow_date' => '2026-09-01',
+            'due_date' => '2026-09-05',
+        ], $rules, $messages);
+
+        $this->assertTrue($validator->fails());
+        $this->assertContains('Jumlah minimal 1', $validator->errors()->get('quantity'));
+
+        // Non-integer quantity
+        $validatorQty = Validator::make([
+            'item_id' => $this->item->id,
+            'quantity' => 'dua',
+            'borrow_date' => '2026-09-01',
+            'due_date' => '2026-09-05',
+        ], $rules, $messages);
+
+        $this->assertTrue($validatorQty->fails());
+        $this->assertContains('Jumlah harus berupa angka', $validatorQty->errors()->get('quantity'));
+
+        // Due date before borrow date
+        $validatorDates = Validator::make([
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'borrow_date' => '2026-09-10',
+            'due_date' => '2026-09-05',
+        ], $rules, $messages);
+
+        $this->assertTrue($validatorDates->fails());
+        $this->assertContains('Tanggal kembali harus setelah atau sama dengan tanggal pinjam', $validatorDates->errors()->get('due_date'));
+    }
+
+    public function test_whitebox_update_borrowing_request_rules_and_messages(): void
+    {
+        $request = new UpdateBorrowingRequest();
+        $rules = $request->rules();
+        $messages = $request->messages();
+
+        $this->assertTrue($request->authorize());
+
+        // Validate status rule
+        $validator = Validator::make([
+            'status' => 'status_tidak_dikenal',
+        ], $rules, $messages);
+
+        $this->assertTrue($validator->fails());
+        $this->assertContains('Status tidak valid', $validator->errors()->get('status'));
+
+        // Validate valid partial update (notes only)
+        $validatorValid = Validator::make([
+            'notes' => 'Catatan perpanjangan peminjaman',
+        ], $rules, $messages);
+
+        $this->assertFalse($validatorValid->fails());
+    }
+
+    /* =========================================================================
+     * ⚫ BLACK-BOX TESTING (HTTP Endpoints & Validation Behavior)
+     * ========================================================================= */
+
+    public function test_blackbox_store_borrowing_fails_with_validation_errors_when_empty(): void
+    {
+        Sanctum::actingAs($this->staff);
+
+        $response = $this->postJson('/api/borrowings', []);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['item_id', 'quantity', 'borrow_date', 'due_date'])
+            ->assertJsonFragment(['item_id' => ['Barang wajib dipilih']])
+            ->assertJsonFragment(['quantity' => ['Jumlah wajib diisi']])
+            ->assertJsonFragment(['borrow_date' => ['Tanggal pinjam wajib diisi']])
+            ->assertJsonFragment(['due_date' => ['Tanggal kembali wajib diisi']]);
+    }
+
+    public function test_blackbox_store_borrowing_fails_when_item_does_not_exist(): void
+    {
+        Sanctum::actingAs($this->staff);
+
+        $response = $this->postJson('/api/borrowings', [
+            'item_id' => 99999,
+            'quantity' => 1,
+            'borrow_date' => '2026-09-01',
+            'due_date' => '2026-09-05',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['item_id'])
+            ->assertJsonFragment(['item_id' => ['Barang tidak ditemukan']]);
+    }
+
+    public function test_blackbox_store_borrowing_succeeds_with_valid_form_request_data(): void
+    {
+        Sanctum::actingAs($this->staff);
+
+        $response = $this->postJson('/api/borrowings', [
+            'item_id' => $this->item->id,
+            'quantity' => 2,
+            'borrow_date' => now()->toDateString(),
+            'due_date' => now()->addDays(4)->toDateString(),
+            'notes' => 'Peminjaman inventaris kantor untuk sesi dokumentasi',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJson([
+                'message' => 'Borrowing created successfully',
+            ])
+            ->assertJsonStructure([
+                'message',
+                'data' => [
+                    'id',
+                    'borrow_code',
+                    'quantity',
+                    'status',
+                    'notes',
+                ],
+            ]);
+    }
+
+    public function test_blackbox_update_borrowing_validates_due_date(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'borrow_date' => '2026-09-01',
+            'due_date' => '2026-09-05',
+            'status' => 'dipinjam',
+        ]);
+
+        // Attempt to update due_date earlier than borrow_date
+        $response = $this->putJson("/api/borrowings/{$borrowing->id}", [
+            'due_date' => '2026-08-25',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['due_date']);
+    }
+
+    public function test_blackbox_update_borrowing_succeeds_with_valid_data(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'borrow_date' => '2026-09-01',
+            'due_date' => '2026-09-05',
+            'status' => 'dipinjam',
+            'notes' => 'Catatan awal',
+        ]);
+
+        $response = $this->putJson("/api/borrowings/{$borrowing->id}", [
+            'notes' => 'Catatan telah diperbarui oleh admin',
+            'due_date' => '2026-09-15',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'Borrowing updated successfully',
+                'data' => [
+                    'id' => $borrowing->id,
+                    'notes' => 'Catatan telah diperbarui oleh admin',
+                ],
+            ]);
+    }
+
+    public function test_blackbox_update_borrowing_fails_if_already_returned(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'status' => 'dikembalikan',
+            'return_date' => '2026-09-02',
+        ]);
+
+        $response = $this->putJson("/api/borrowings/{$borrowing->id}", [
+            'notes' => 'Mencoba update yang sudah dikembalikan',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'message' => 'Cannot update returned borrowing',
+            ]);
+    }
+
+    /* =========================================================================
+     * 🔘 GREY-BOX TESTING (Database Integrity & Side-Effects)
+     * ========================================================================= */
+
+    public function test_greybox_validation_failure_prevents_database_mutation_and_stock_deduction(): void
+    {
+        Sanctum::actingAs($this->staff);
+
+        $initialStock = $this->item->fresh()->available_stock;
+        $initialBorrowingsCount = Borrowing::count();
+
+        // Invalid request (missing quantity and invalid item_id)
+        $response = $this->postJson('/api/borrowings', [
+            'item_id' => 999999,
+            'borrow_date' => '2026-09-01',
+            'due_date' => '2026-09-05',
+        ]);
+
+        $response->assertStatus(422);
+
+        // Verify no borrowing record created
+        $this->assertEquals($initialBorrowingsCount, Borrowing::count());
+
+        // Verify available stock unchanged
+        $this->assertEquals($initialStock, $this->item->fresh()->available_stock);
+    }
+
+    public function test_greybox_update_borrowing_persists_only_allowed_attributes(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'borrow_date' => '2026-09-01',
+            'due_date' => '2026-09-05',
+            'status' => 'dipinjam',
+            'notes' => 'Catatan awal',
+        ]);
+
+        $originalCode = $borrowing->borrow_code;
+        $originalUserId = $borrowing->user_id;
+
+        $response = $this->putJson("/api/borrowings/{$borrowing->id}", [
+            'notes' => 'Catatan revisi',
+            'due_date' => '2026-09-12',
+        ]);
+
+        $response->assertStatus(200);
+
+        $borrowing->refresh();
+
+        $this->assertEquals('Catatan revisi', $borrowing->notes);
+        $this->assertEquals('2026-09-12', $borrowing->due_date->format('Y-m-d'));
+        // Core identifiers remain unchanged
+        $this->assertEquals($originalCode, $borrowing->borrow_code);
+        $this->assertEquals($originalUserId, $borrowing->user_id);
+    }
+}


### PR DESCRIPTION
## Summary
Closes #29

This PR implements **R5 & R6** from Phase 2 of the roadmap:
1. **Adopt `StoreBorrowingRequest` in `BorrowingController::store()`**:
   - Replaced generic `Request $request` and inline `$request->validate()` with `StoreBorrowingRequest $request`.
   - Utilized `$request->validated()` when dispatching to `BorrowingService::createBorrowing`.
   - Cleaned up unlocked preliminary stock checks in FormRequest to let `BorrowingService` execute authoritative stock validation within pessimistic locking transaction (`Item::lockForUpdate()`), preventing concurrency race condition flaws.
2. **Adopt `UpdateBorrowingRequest` in `BorrowingController::update()`**:
   - Replaced generic `Request $request` and inline validation with `UpdateBorrowingRequest $request`.
   - Added `prepareForValidation()` to automatically resolve `borrow_date` from route model when only `due_date` or `notes` are updated.
   - Handled friendly Indonesian custom validation error messages.
3. **Automated Testing (3 Methodologies)**:
   - Added `BorrowingFormRequestTest.php` (11 tests, 59 assertions) passing 100%.
   - Full suite of 12 feature test suites (138 tests, 662 assertions) passing 100%.

## Automated Testing (3 Methodologies)
- **⚪ White-Box Testing**:
  - Direct unit test of `StoreBorrowingRequest` and `UpdateBorrowingRequest` rules and custom error messages.
  - Verification of boundary conditions (`quantity < 1`, non-integer values, `due_date < borrow_date`).
  - Verification of partial update validation rules.
- **⚫ Black-Box Testing**:
  - API tests on `POST /api/borrowings`: validation failure on missing fields (422), non-existent `item_id` (422), and success with valid data (201).
  - API tests on `PUT /api/borrowings/{id}`: invalid due date (422), already returned borrowing (422), and valid partial updates (200).
- **🔘 Grey-Box Testing**:
  - Verification that FormRequest validation failures prevent database records from being created or stock from being deducted.
  - Verification that partial updates via `PUT /api/borrowings/{id}` only persist allowed attributes while keeping identifiers (`user_id`, `borrow_code`) intact.
