### PR TITLE
refactor(models): create BorrowingStatus PHP backed enum (R15)

### DIFF
--- a/app/Enums/BorrowingStatus.php
+++ b/app/Enums/BorrowingStatus.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Enums;
+
+enum BorrowingStatus: string
+{
+    case Pending = 'pending';
+    case Dipinjam = 'dipinjam';
+    case Dikembalikan = 'dikembalikan';
+    case Terlambat = 'terlambat';
+    case Ditolak = 'ditolak';
+    case Approved = 'approved';
+    case Rejected = 'rejected';
+
+    /**
+     * Get all raw string values of the enum cases.
+     *
+     * @return array<string>
+     */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    /**
+     * Get human-readable Indonesian label.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::Pending => 'Menunggu Persetujuan',
+            self::Dipinjam, self::Approved => 'Sedang Dipinjam',
+            self::Dikembalikan => 'Dikembalikan',
+            self::Terlambat => 'Terlambat',
+            self::Ditolak, self::Rejected => 'Ditolak',
+        };
+    }
+
+    /**
+     * Get UI badge color theme.
+     */
+    public function badgeColor(): string
+    {
+        return match ($this) {
+            self::Pending => 'warning',
+            self::Dipinjam, self::Approved => 'info',
+            self::Dikembalikan => 'success',
+            self::Terlambat => 'danger',
+            self::Ditolak, self::Rejected => 'secondary',
+        };
+    }
+
+    /**
+     * Check if the borrowing is in an active state (item currently in user's possession).
+     */
+    public function isActive(): bool
+    {
+        return in_array($this, [self::Dipinjam, self::Approved, self::Terlambat], true);
+    }
+
+    /**
+     * Check if the borrowing is in a finished / final state.
+     */
+    public function isFinal(): bool
+    {
+        return in_array($this, [self::Dikembalikan, self::Ditolak, self::Rejected], true);
+    }
+
+    /**
+     * Check if the borrowing can be returned.
+     */
+    public function canBeReturned(): bool
+    {
+        return in_array($this, [self::Dipinjam, self::Approved, self::Terlambat], true);
+    }
+
+    /**
+     * Check if the borrowing can have its due date extended.
+     */
+    public function canBeExtended(): bool
+    {
+        return in_array($this, [self::Dipinjam, self::Approved], true);
+    }
+
+    /**
+     * Check if the borrowing can be approved or rejected by admin.
+     */
+    public function canBeActioned(): bool
+    {
+        return $this === self::Pending;
+    }
+}

--- a/app/Exports/BorrowingsExport.php
+++ b/app/Exports/BorrowingsExport.php
@@ -73,7 +73,7 @@ class BorrowingsExport implements FromCollection, WithHeadings, WithMapping, Wit
             $borrowing->borrow_date->format('d/m/Y'),
             $borrowing->due_date->format('d/m/Y'),
             $borrowing->return_date ? $borrowing->return_date->format('d/m/Y') : '-',
-            ucfirst($borrowing->status),
+            $borrowing->status instanceof \App\Enums\BorrowingStatus ? $borrowing->status->label() : ucfirst((string) $borrowing->status),
             $borrowing->approver ? $borrowing->approver->name : '-',
             $borrowing->notes ?? '-',
         ];

--- a/app/Http/Controllers/Api/BorrowingController.php
+++ b/app/Http/Controllers/Api/BorrowingController.php
@@ -212,7 +212,8 @@ class BorrowingController extends Controller
      */
     public function update(UpdateBorrowingRequest $request, Borrowing $borrowing)
     {
-        if ($borrowing->status === 'dikembalikan') {
+        $statusValue = $borrowing->status instanceof \App\Enums\BorrowingStatus ? $borrowing->status->value : (string) $borrowing->status;
+        if ($statusValue === \App\Enums\BorrowingStatus::Dikembalikan->value) {
             return response()->json([
                 'message' => 'Cannot update returned borrowing',
             ], 422);

--- a/app/Http/Resources/BorrowingResource.php
+++ b/app/Http/Resources/BorrowingResource.php
@@ -14,8 +14,9 @@ class BorrowingResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        $isOverdue = ($this->status === 'terlambat') || 
-            ($this->status === 'dipinjam' && $this->due_date && $this->due_date->isPast());
+        $statusValue = $this->status instanceof \App\Enums\BorrowingStatus ? $this->status->value : (string) $this->status;
+        $isOverdue = ($statusValue === 'terlambat') || 
+            ($statusValue === 'dipinjam' && $this->due_date && $this->due_date->isPast());
 
         $daysOverdue = ($isOverdue && $this->due_date) ? abs((int) now()->diffInDays($this->due_date)) : 0;
 
@@ -29,7 +30,7 @@ class BorrowingResource extends JsonResource
             'borrow_date' => $this->borrow_date?->format('Y-m-d'),
             'due_date' => $this->due_date?->format('Y-m-d'),
             'return_date' => $this->return_date?->format('Y-m-d'),
-            'status' => $this->status,
+            'status' => $statusValue,
             'notes' => $this->notes,
             'approved_by' => $this->approved_by,
             'approved_at' => $this->approved_at?->format('Y-m-d H:i:s'),

--- a/app/Models/Borrowing.php
+++ b/app/Models/Borrowing.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Activitylog\Traits\LogsActivity;
 use Spatie\Activitylog\LogOptions;
+use App\Enums\BorrowingStatus;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 
@@ -43,6 +44,7 @@ class Borrowing extends Model
         'return_date' => 'datetime',
         'approved_at' => 'datetime',
         'quantity' => 'integer',
+        'status' => BorrowingStatus::class,
     ];
 
     /**
@@ -91,7 +93,8 @@ class Borrowing extends Model
      */
     public function isOverdue(): bool
     {
-        if ($this->status === 'dikembalikan') {
+        $statusValue = $this->status instanceof BorrowingStatus ? $this->status->value : (string) $this->status;
+        if ($statusValue === BorrowingStatus::Dikembalikan->value) {
             return false;
         }
 
@@ -103,8 +106,9 @@ class Borrowing extends Model
      */
     public function updateOverdueStatus(): void
     {
-        if ($this->isOverdue() && $this->status === 'dipinjam') {
-            $this->status = 'terlambat';
+        $statusValue = $this->status instanceof BorrowingStatus ? $this->status->value : (string) $this->status;
+        if ($this->isOverdue() && $statusValue === BorrowingStatus::Dipinjam->value) {
+            $this->status = BorrowingStatus::Terlambat;
             $this->save();
         }
     }
@@ -127,21 +131,23 @@ class Borrowing extends Model
      */
     public function processReturn(): bool
     {
-        if ($this->status === 'dikembalikan') {
+        $statusValue = $this->status instanceof BorrowingStatus ? $this->status->value : (string) $this->status;
+        if ($statusValue === BorrowingStatus::Dikembalikan->value) {
             return false;
         }
 
         return DB::transaction(function () {
             // Re-check after acquiring transaction to prevent race conditions
             $this->refresh();
-            if ($this->status === 'dikembalikan') {
+            $statusValue = $this->status instanceof BorrowingStatus ? $this->status->value : (string) $this->status;
+            if ($statusValue === BorrowingStatus::Dikembalikan->value) {
                 return false;
             }
 
             $item = Item::lockForUpdate()->find($this->item_id);
 
             $this->return_date = now();
-            $this->status = 'dikembalikan';
+            $this->status = BorrowingStatus::Dikembalikan;
             $this->save();
 
             // Update item stock
@@ -158,7 +164,7 @@ class Borrowing extends Model
      */
     public function scopeActive($query)
     {
-        return $query->where('status', 'dipinjam');
+        return $query->where('status', BorrowingStatus::Dipinjam->value);
     }
 
     /**
@@ -166,7 +172,7 @@ class Borrowing extends Model
      */
     public function scopeOverdue($query)
     {
-        return $query->where('status', 'terlambat');
+        return $query->where('status', BorrowingStatus::Terlambat->value);
     }
 
     /**
@@ -174,7 +180,7 @@ class Borrowing extends Model
      */
     public function scopeReturned($query)
     {
-        return $query->where('status', 'dikembalikan');
+        return $query->where('status', BorrowingStatus::Dikembalikan->value);
     }
 
     /**

--- a/app/Services/BorrowingService.php
+++ b/app/Services/BorrowingService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Enums\BorrowingStatus;
 use App\Exceptions\BorrowingException;
 use App\Jobs\SendBorrowingNotification;
 use App\Jobs\SendOverdueNotification;
@@ -17,6 +18,18 @@ class BorrowingService
     public function __construct(ItemService $itemService)
     {
         $this->itemService = $itemService;
+    }
+
+    /**
+     * Get string status value from model or string.
+     */
+    private function getStatusValue(Borrowing $borrowing): string
+    {
+        if ($borrowing->status instanceof BorrowingStatus) {
+            return $borrowing->status->value;
+        }
+
+        return (string) $borrowing->status;
     }
 
     /**
@@ -80,7 +93,8 @@ class BorrowingService
     public function approveBorrowing(Borrowing $borrowing, int $approverId): Borrowing
     {
         // Initial guard
-        if ($borrowing->approved_by !== null || in_array($borrowing->status, ['approved', 'dipinjam', 'dikembalikan', 'terlambat', 'ditolak', 'rejected'])) {
+        $status = $this->getStatusValue($borrowing);
+        if ($borrowing->approved_by !== null || in_array($status, ['approved', 'dipinjam', 'dikembalikan', 'terlambat', 'ditolak', 'rejected'])) {
             throw new BorrowingException('Peminjaman sudah diproses atau sudah disetujui.', 400);
         }
 
@@ -88,7 +102,8 @@ class BorrowingService
             /** @var Borrowing $lockedBorrowing */
             $lockedBorrowing = Borrowing::lockForUpdate()->findOrFail($borrowing->id);
 
-            if ($lockedBorrowing->approved_by !== null || in_array($lockedBorrowing->status, ['approved', 'dipinjam', 'dikembalikan', 'terlambat', 'ditolak', 'rejected'])) {
+            $lockedStatus = $this->getStatusValue($lockedBorrowing);
+            if ($lockedBorrowing->approved_by !== null || in_array($lockedStatus, ['approved', 'dipinjam', 'dikembalikan', 'terlambat', 'ditolak', 'rejected'])) {
                 throw new BorrowingException('Peminjaman sudah diproses atau sudah disetujui.', 400);
             }
 
@@ -96,7 +111,7 @@ class BorrowingService
             $item = Item::lockForUpdate()->findOrFail($lockedBorrowing->item_id);
 
             // If status is pending, deduct stock upon approval
-            if ($lockedBorrowing->status === 'pending') {
+            if ($lockedStatus === 'pending') {
                 if (!$item->isAvailable($lockedBorrowing->quantity)) {
                     throw new BorrowingException(
                         'Stok barang tidak mencukupi untuk disetujui.',
@@ -108,7 +123,7 @@ class BorrowingService
                 $this->itemService->decreaseStock($item, $lockedBorrowing->quantity);
             }
 
-            $lockedBorrowing->status = 'dipinjam';
+            $lockedBorrowing->status = BorrowingStatus::Dipinjam;
             $lockedBorrowing->approved_by = $approverId;
             $lockedBorrowing->approved_at = now();
             $lockedBorrowing->save();
@@ -135,7 +150,8 @@ class BorrowingService
      */
     public function rejectBorrowing(Borrowing $borrowing): Borrowing
     {
-        if ($borrowing->approved_by !== null || in_array($borrowing->status, ['approved', 'dipinjam', 'dikembalikan', 'terlambat', 'ditolak', 'rejected'])) {
+        $status = $this->getStatusValue($borrowing);
+        if ($borrowing->approved_by !== null || in_array($status, ['approved', 'dipinjam', 'dikembalikan', 'terlambat', 'ditolak', 'rejected'])) {
             throw new BorrowingException('Peminjaman sudah diproses.', 400);
         }
 
@@ -143,11 +159,12 @@ class BorrowingService
             /** @var Borrowing $lockedBorrowing */
             $lockedBorrowing = Borrowing::lockForUpdate()->findOrFail($borrowing->id);
 
-            if ($lockedBorrowing->approved_by !== null || in_array($lockedBorrowing->status, ['approved', 'dipinjam', 'dikembalikan', 'terlambat', 'ditolak', 'rejected'])) {
+            $lockedStatus = $this->getStatusValue($lockedBorrowing);
+            if ($lockedBorrowing->approved_by !== null || in_array($lockedStatus, ['approved', 'dipinjam', 'dikembalikan', 'terlambat', 'ditolak', 'rejected'])) {
                 throw new BorrowingException('Peminjaman sudah diproses.', 400);
             }
 
-            $lockedBorrowing->status = 'rejected';
+            $lockedBorrowing->status = BorrowingStatus::Rejected;
             $lockedBorrowing->save();
 
             $lockedBorrowing->load(['user', 'item', 'approver']);
@@ -163,7 +180,8 @@ class BorrowingService
      */
     public function returnBorrowing(Borrowing $borrowing, ?string $returnDate = null): Borrowing
     {
-        if ($borrowing->status === 'dikembalikan') {
+        $status = $this->getStatusValue($borrowing);
+        if ($status === 'dikembalikan') {
             throw new BorrowingException('Item already returned', 422);
         }
 
@@ -171,11 +189,12 @@ class BorrowingService
             /** @var Borrowing $lockedBorrowing */
             $lockedBorrowing = Borrowing::lockForUpdate()->findOrFail($borrowing->id);
 
-            if ($lockedBorrowing->status === 'dikembalikan') {
+            $lockedStatus = $this->getStatusValue($lockedBorrowing);
+            if ($lockedStatus === 'dikembalikan') {
                 throw new BorrowingException('Item already returned', 422);
             }
 
-            if ($lockedBorrowing->status !== 'dipinjam' && $lockedBorrowing->status !== 'terlambat') {
+            if ($lockedStatus !== 'dipinjam' && $lockedStatus !== 'terlambat') {
                 throw new BorrowingException('Status peminjaman tidak valid untuk pengembalian', 422);
             }
 
@@ -185,7 +204,7 @@ class BorrowingService
             $parsedReturnDate = $returnDate ? Carbon::parse($returnDate) : now();
 
             $lockedBorrowing->return_date = $parsedReturnDate;
-            $lockedBorrowing->status = 'dikembalikan';
+            $lockedBorrowing->status = BorrowingStatus::Dikembalikan;
             $lockedBorrowing->save();
 
             // Increase available stock
@@ -204,7 +223,8 @@ class BorrowingService
      */
     public function cancelBorrowing(Borrowing $borrowing): bool
     {
-        if ($borrowing->status !== 'pending') {
+        $status = $this->getStatusValue($borrowing);
+        if ($status !== 'pending') {
             throw new BorrowingException('Hanya peminjaman dengan status pending yang dapat dibatalkan', 422);
         }
 
@@ -218,7 +238,8 @@ class BorrowingService
      */
     public function deleteBorrowing(Borrowing $borrowing): bool
     {
-        if ($borrowing->status === 'dipinjam' || $borrowing->status === 'terlambat') {
+        $status = $this->getStatusValue($borrowing);
+        if ($status === 'dipinjam' || $status === 'terlambat') {
             throw new BorrowingException('Cannot delete active borrowing. Please return the item first.', 422);
         }
 
@@ -232,7 +253,8 @@ class BorrowingService
      */
     public function extendBorrowing(Borrowing $borrowing, string $newDueDate): Borrowing
     {
-        if ($borrowing->status !== 'dipinjam') {
+        $status = $this->getStatusValue($borrowing);
+        if ($status !== 'dipinjam') {
             throw new BorrowingException('Only active borrowings can be extended', 422);
         }
 

--- a/app/Services/ReportService.php
+++ b/app/Services/ReportService.php
@@ -339,7 +339,7 @@ class ReportService
                     'borrow_date' => $borrowDate->format('Y-m-d'),
                     'due_date' => $dueDate->format('Y-m-d'),
                     'return_date' => $borrowing->return_date?->format('Y-m-d'),
-                    'status' => $borrowing->status,
+                    'status' => $borrowing->status instanceof \App\Enums\BorrowingStatus ? $borrowing->status->value : $borrowing->status,
                 ];
             })
             ->toArray();

--- a/tests/Feature/BorrowingStatusEnumTest.php
+++ b/tests/Feature/BorrowingStatusEnumTest.php
@@ -1,0 +1,302 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\BorrowingStatus;
+use App\Models\Borrowing;
+use App\Models\Category;
+use App\Models\Item;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use ValueError;
+
+class BorrowingStatusEnumTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+    private User $staff;
+    private Item $item;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create([
+            'role' => 'admin',
+            'email' => 'admin_enum@example.com',
+        ]);
+
+        $this->staff = User::factory()->create([
+            'role' => 'staff',
+            'email' => 'staff_enum@example.com',
+        ]);
+
+        $category = Category::factory()->create();
+        $this->item = Item::factory()->create([
+            'category_id' => $category->id,
+            'stock' => 10,
+            'available_stock' => 10,
+        ]);
+    }
+
+    // ==========================================
+    // ⚪ WHITE-BOX TESTING: Enum Structure & Logic
+    // ==========================================
+
+    public function test_whitebox_enum_cases_and_backing_values(): void
+    {
+        $expectedValues = [
+            'pending',
+            'dipinjam',
+            'dikembalikan',
+            'terlambat',
+            'ditolak',
+            'approved',
+            'rejected',
+        ];
+
+        $actualValues = BorrowingStatus::values();
+
+        $this->assertSame($expectedValues, $actualValues);
+        $this->assertSame('pending', BorrowingStatus::Pending->value);
+        $this->assertSame('dipinjam', BorrowingStatus::Dipinjam->value);
+        $this->assertSame('dikembalikan', BorrowingStatus::Dikembalikan->value);
+        $this->assertSame('terlambat', BorrowingStatus::Terlambat->value);
+        $this->assertSame('ditolak', BorrowingStatus::Ditolak->value);
+        $this->assertSame('approved', BorrowingStatus::Approved->value);
+        $this->assertSame('rejected', BorrowingStatus::Rejected->value);
+
+        // Test from and tryFrom
+        $this->assertSame(BorrowingStatus::Dipinjam, BorrowingStatus::from('dipinjam'));
+        $this->assertNull(BorrowingStatus::tryFrom('non_existent_status'));
+
+        $this->expectException(ValueError::class);
+        BorrowingStatus::from('invalid_value');
+    }
+
+    public function test_whitebox_enum_helper_methods(): void
+    {
+        // Test labels
+        $this->assertSame('Menunggu Persetujuan', BorrowingStatus::Pending->label());
+        $this->assertSame('Sedang Dipinjam', BorrowingStatus::Dipinjam->label());
+        $this->assertSame('Dikembalikan', BorrowingStatus::Dikembalikan->label());
+        $this->assertSame('Terlambat', BorrowingStatus::Terlambat->label());
+        $this->assertSame('Ditolak', BorrowingStatus::Ditolak->label());
+
+        // Test badge colors
+        $this->assertSame('warning', BorrowingStatus::Pending->badgeColor());
+        $this->assertSame('info', BorrowingStatus::Dipinjam->badgeColor());
+        $this->assertSame('success', BorrowingStatus::Dikembalikan->badgeColor());
+        $this->assertSame('danger', BorrowingStatus::Terlambat->badgeColor());
+        $this->assertSame('secondary', BorrowingStatus::Ditolak->badgeColor());
+
+        // Test state checkers
+        $this->assertTrue(BorrowingStatus::Dipinjam->isActive());
+        $this->assertTrue(BorrowingStatus::Terlambat->isActive());
+        $this->assertFalse(BorrowingStatus::Pending->isActive());
+        $this->assertFalse(BorrowingStatus::Dikembalikan->isActive());
+
+        $this->assertTrue(BorrowingStatus::Dikembalikan->isFinal());
+        $this->assertTrue(BorrowingStatus::Ditolak->isFinal());
+        $this->assertTrue(BorrowingStatus::Rejected->isFinal());
+        $this->assertFalse(BorrowingStatus::Dipinjam->isFinal());
+        $this->assertFalse(BorrowingStatus::Pending->isFinal());
+
+        $this->assertTrue(BorrowingStatus::Dipinjam->canBeReturned());
+        $this->assertTrue(BorrowingStatus::Terlambat->canBeReturned());
+        $this->assertFalse(BorrowingStatus::Dikembalikan->canBeReturned());
+
+        $this->assertTrue(BorrowingStatus::Dipinjam->canBeExtended());
+        $this->assertFalse(BorrowingStatus::Terlambat->canBeExtended());
+        $this->assertFalse(BorrowingStatus::Dikembalikan->canBeExtended());
+
+        $this->assertTrue(BorrowingStatus::Pending->canBeActioned());
+        $this->assertFalse(BorrowingStatus::Dipinjam->canBeActioned());
+    }
+
+    // ==========================================
+    // ⚫ BLACK-BOX TESTING: API Response Serialization
+    // ==========================================
+
+    public function test_blackbox_borrowing_api_returns_status_string_in_json(): void
+    {
+        $borrowing = Borrowing::create([
+            'borrow_code' => 'BRW-TEST-001',
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 2,
+            'borrow_date' => now(),
+            'due_date' => now()->addDays(3),
+            'status' => BorrowingStatus::Dipinjam,
+        ]);
+
+        // Test unversioned
+        $response = $this->actingAs($this->admin, 'sanctum')
+            ->getJson('/api/borrowings');
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'data' => [
+                    '*' => [
+                        'id',
+                        'borrow_code',
+                        'status',
+                    ],
+                ],
+            ]);
+
+        $this->assertSame('dipinjam', $response->json('data.0.status'));
+
+        // Test versioned /v1
+        $responseV1 = $this->actingAs($this->admin, 'sanctum')
+            ->getJson('/api/v1/borrowings');
+
+        $responseV1->assertOk();
+        $this->assertSame('dipinjam', $responseV1->json('data.0.status'));
+    }
+
+    public function test_blackbox_update_borrowing_respects_status_restriction(): void
+    {
+        $borrowing = Borrowing::create([
+            'borrow_code' => 'BRW-RET-001',
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'borrow_date' => now()->subDays(5),
+            'due_date' => now()->subDays(2),
+            'return_date' => now(),
+            'status' => BorrowingStatus::Dikembalikan,
+        ]);
+
+        $response = $this->actingAs($this->admin, 'sanctum')
+            ->putJson("/api/borrowings/{$borrowing->id}", [
+                'notes' => 'Attempting to edit returned item',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'message' => 'Cannot update returned borrowing',
+            ]);
+    }
+
+    // ==========================================
+    // 🔘 GREY-BOX TESTING: Eloquent Casting & Persistence
+    // ==========================================
+
+    public function test_greybox_eloquent_casts_status_attribute_to_enum(): void
+    {
+        $borrowing = Borrowing::create([
+            'borrow_code' => 'BRW-CAST-001',
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'borrow_date' => now(),
+            'due_date' => now()->addDays(7),
+            'status' => 'dipinjam',
+        ]);
+
+        // Fetch fresh instance from DB
+        $fresh = Borrowing::findOrFail($borrowing->id);
+
+        $this->assertInstanceOf(BorrowingStatus::class, $fresh->status);
+        $this->assertSame(BorrowingStatus::Dipinjam, $fresh->status);
+        $this->assertSame('dipinjam', $fresh->status->value);
+    }
+
+    public function test_greybox_assigning_enum_persists_raw_string_in_database(): void
+    {
+        $borrowing = new Borrowing();
+        $borrowing->borrow_code = 'BRW-ENUM-002';
+        $borrowing->user_id = $this->staff->id;
+        $borrowing->item_id = $this->item->id;
+        $borrowing->quantity = 1;
+        $borrowing->borrow_date = now();
+        $borrowing->due_date = now()->addDays(5);
+        $borrowing->status = BorrowingStatus::Pending;
+        $borrowing->save();
+
+        $this->assertDatabaseHas('borrowings', [
+            'id' => $borrowing->id,
+            'status' => 'pending',
+        ]);
+
+        // Transition status using Enum
+        $borrowing->status = BorrowingStatus::Dikembalikan;
+        $borrowing->save();
+
+        $this->assertDatabaseHas('borrowings', [
+            'id' => $borrowing->id,
+            'status' => 'dikembalikan',
+        ]);
+    }
+
+    public function test_greybox_query_scopes_work_seamlessly_with_enum(): void
+    {
+        // Create records with various statuses
+        Borrowing::create([
+            'borrow_code' => 'BRW-ACT-001',
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'borrow_date' => now(),
+            'due_date' => now()->addDays(3),
+            'status' => BorrowingStatus::Dipinjam,
+        ]);
+
+        Borrowing::create([
+            'borrow_code' => 'BRW-OVD-001',
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'borrow_date' => now()->subDays(10),
+            'due_date' => now()->subDays(3),
+            'status' => BorrowingStatus::Terlambat,
+        ]);
+
+        Borrowing::create([
+            'borrow_code' => 'BRW-RET-002',
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'borrow_date' => now()->subDays(5),
+            'due_date' => now()->subDays(1),
+            'return_date' => now(),
+            'status' => BorrowingStatus::Dikembalikan,
+        ]);
+
+        $this->assertCount(1, Borrowing::active()->get());
+        $this->assertCount(1, Borrowing::overdue()->get());
+        $this->assertCount(1, Borrowing::returned()->get());
+
+        $this->assertSame('BRW-ACT-001', Borrowing::active()->first()->borrow_code);
+        $this->assertSame('BRW-OVD-001', Borrowing::overdue()->first()->borrow_code);
+        $this->assertSame('BRW-RET-002', Borrowing::returned()->first()->borrow_code);
+    }
+
+    public function test_greybox_process_return_uses_enum_and_restores_stock(): void
+    {
+        $this->item->update(['available_stock' => 8]);
+
+        $borrowing = Borrowing::create([
+            'borrow_code' => 'BRW-RET-003',
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 2,
+            'borrow_date' => now()->subDays(2),
+            'due_date' => now()->addDays(2),
+            'status' => BorrowingStatus::Dipinjam,
+        ]);
+
+        $result = $borrowing->processReturn();
+
+        $this->assertTrue($result);
+        $this->assertSame(BorrowingStatus::Dikembalikan, $borrowing->fresh()->status);
+        $this->assertSame(10, $this->item->fresh()->available_stock);
+
+        // Attempting second return should fail
+        $this->assertFalse($borrowing->processReturn());
+    }
+}


### PR DESCRIPTION
## Summary

This PR addresses and resolves Issue #39 (**Task R15** from Phase 4 of `docs/ROADMAP_TASKS.md`):
- **New Backed Enum (`app/Enums/BorrowingStatus.php`)**:
  - String-backed enum covering all borrowing statuses: `Pending = 'pending'`, `Dipinjam = 'dipinjam'`, `Dikembalikan = 'dikembalikan'`, `Terlambat = 'terlambat'`, `Ditolak = 'ditolak'`, `Approved = 'approved'`, `Rejected = 'rejected'`.
  - Helper methods:
    - `values(): array` — returns all raw backing values.
    - `label(): string` — Indonesian human-readable status labels.
    - `badgeColor(): string` — UI color mapping (warning, info, success, danger, secondary).
    - `isActive(): bool` — identifies in-progress borrowings (`dipinjam`, `approved`, `terlambat`).
    - `isFinal(): bool` — identifies completed/closed borrowings (`dikembalikan`, `ditolak`, `rejected`).
    - `canBeReturned(): bool` & `canBeExtended(): bool` — domain state guards.
    - `canBeActioned(): bool` — approval/rejection capability checks.
- **Model Integration & Type-Safety (`app/Models/Borrowing.php`)**:
  - Registered `'status' => BorrowingStatus::class` in `$casts`.
  - Updated model methods (`isOverdue()`, `updateOverdueStatus()`, `processReturn()`) and scopes (`active`, `overdue`, `returned`) to support both enum instances and raw values.
- **Service & API Compatibility**:
  - Updated `BorrowingService`, `BorrowingResource`, `BorrowingController`, `ReportService`, and `BorrowingsExport` to ensure seamless interop and guarantee that API JSON serialization preserves backward-compatible strings.
- **Tri-Layer Automated Testing (`tests/Feature/BorrowingStatusEnumTest.php`)**:
  - ⚪ **White-box**: Enum cases, values, labels, badge colors, state checkers, `from()`, and `tryFrom()`.
  - ⚫ **Black-box**: API endpoints `/api/borrowings` and `/api/v1/borrowings` serialize string statuses correctly; status restrictions in `PUT /api/borrowings/{id}` enforced with 422.
  - 🔘 **Grey-box**: Database persistence of enum instances, Eloquent retrieval casting, query scopes (`active()`, `overdue()`, `returned()`), and `processReturn()` stock handling.

Closes #39
