### PR TITLE
refactor(models): create ItemCondition PHP backed enum (R16)

### DIFF
--- a/app/Enums/ItemCondition.php
+++ b/app/Enums/ItemCondition.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Enums;
+
+enum ItemCondition: string
+{
+    case Baik = 'baik';
+    case Rusak = 'rusak';
+    case Hilang = 'hilang';
+
+    /**
+     * Get all raw string values of the enum cases.
+     *
+     * @return array<string>
+     */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    /**
+     * Get human-readable Indonesian label.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::Baik => 'Baik',
+            self::Rusak => 'Rusak',
+            self::Hilang => 'Hilang',
+        };
+    }
+
+    /**
+     * Get UI badge color theme.
+     */
+    public function badgeColor(): string
+    {
+        return match ($this) {
+            self::Baik => 'success',
+            self::Rusak => 'warning',
+            self::Hilang => 'danger',
+        };
+    }
+
+    /**
+     * Determine if an item with this condition can be borrowed.
+     */
+    public function isBorrowable(): bool
+    {
+        return $this === self::Baik;
+    }
+}

--- a/app/Http/Requests/StoreItemRequest.php
+++ b/app/Http/Requests/StoreItemRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests;
 
+use App\Enums\ItemCondition;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreItemRequest extends FormRequest
 {
@@ -26,7 +28,7 @@ class StoreItemRequest extends FormRequest
             'category_id' => 'required|exists:categories,id',
             'description' => 'nullable|string|max:1000',
             'stock' => 'required|integer|min:0|max:999999',
-            'condition' => 'required|in:baik,rusak,hilang',
+            'condition' => ['required', Rule::enum(ItemCondition::class)],
             'image' => 'nullable|image|mimes:jpeg,png,jpg|max:2048',
         ];
     }
@@ -48,6 +50,8 @@ class StoreItemRequest extends FormRequest
             'stock.min' => 'Stok minimal 0',
             'condition.required' => 'Kondisi barang wajib dipilih',
             'condition.in' => 'Kondisi barang tidak valid',
+            'condition.Illuminate\Validation\Rules\Enum' => 'Kondisi barang tidak valid',
+            'condition.enum' => 'Kondisi barang tidak valid',
             'image.image' => 'File harus berupa gambar',
             'image.mimes' => 'Format gambar harus jpeg, png, atau jpg',
             'image.max' => 'Ukuran gambar maksimal 2MB',

--- a/app/Http/Requests/UpdateItemRequest.php
+++ b/app/Http/Requests/UpdateItemRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests;
 
+use App\Enums\ItemCondition;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateItemRequest extends FormRequest
 {
@@ -26,7 +28,7 @@ class UpdateItemRequest extends FormRequest
             'category_id' => 'sometimes|required|exists:categories,id',
             'description' => 'nullable|string|max:1000',
             'stock' => 'sometimes|required|integer|min:0|max:999999',
-            'condition' => 'sometimes|required|in:baik,rusak,hilang',
+            'condition' => ['sometimes', 'required', Rule::enum(ItemCondition::class)],
             'image' => 'nullable|image|mimes:jpeg,png,jpg|max:2048',
         ];
     }
@@ -80,6 +82,8 @@ class UpdateItemRequest extends FormRequest
             'stock.min' => 'Stok minimal 0',
             'condition.required' => 'Kondisi barang wajib dipilih',
             'condition.in' => 'Kondisi barang tidak valid',
+            'condition.Illuminate\Validation\Rules\Enum' => 'Kondisi barang tidak valid',
+            'condition.enum' => 'Kondisi barang tidak valid',
             'image.image' => 'File harus berupa gambar',
             'image.mimes' => 'Format gambar harus jpeg, png, atau jpg',
             'image.max' => 'Ukuran gambar maksimal 2MB',

--- a/app/Http/Resources/ItemResource.php
+++ b/app/Http/Resources/ItemResource.php
@@ -22,7 +22,7 @@ class ItemResource extends JsonResource
             'category_id' => $this->category_id,
             'stock' => (int) $this->stock,
             'available_stock' => (int) $this->available_stock,
-            'condition' => $this->condition,
+            'condition' => $this->condition instanceof \App\Enums\ItemCondition ? $this->condition->value : (string) $this->condition,
             'image' => $this->image,
             'image_url' => $this->image ? asset('storage/' . $this->image) : null,
             'created_at' => $this->created_at?->format('Y-m-d H:i:s'),

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\ItemCondition;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -36,6 +37,7 @@ class Item extends Model
     protected $casts = [
         'stock' => 'integer',
         'available_stock' => 'integer',
+        'condition' => ItemCondition::class,
     ];
 
     /**
@@ -67,7 +69,32 @@ class Item extends Model
      */
     public function isAvailable($quantity = 1): bool
     {
-        return $this->available_stock >= $quantity && $this->condition === 'baik';
+        $conditionValue = $this->condition instanceof ItemCondition ? $this->condition->value : (string) $this->condition;
+        return $this->available_stock >= $quantity && $conditionValue === ItemCondition::Baik->value;
+    }
+
+    /**
+     * Scope items in good condition.
+     */
+    public function scopeGood($query)
+    {
+        return $query->where('condition', ItemCondition::Baik->value);
+    }
+
+    /**
+     * Scope items in damaged condition.
+     */
+    public function scopeDamaged($query)
+    {
+        return $query->where('condition', ItemCondition::Rusak->value);
+    }
+
+    /**
+     * Scope items in lost condition.
+     */
+    public function scopeLost($query)
+    {
+        return $query->where('condition', ItemCondition::Hilang->value);
     }
 
     /**

--- a/tests/Feature/ItemConditionEnumTest.php
+++ b/tests/Feature/ItemConditionEnumTest.php
@@ -1,0 +1,269 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\ItemCondition;
+use App\Models\Category;
+use App\Models\Item;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use ValueError;
+
+class ItemConditionEnumTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+    private User $staff;
+    private Category $category;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create([
+            'role' => 'admin',
+            'email' => 'admin_cond@example.com',
+        ]);
+
+        $this->staff = User::factory()->create([
+            'role' => 'staff',
+            'email' => 'staff_cond@example.com',
+        ]);
+
+        $this->category = Category::factory()->create();
+    }
+
+    // ==========================================
+    // ⚪ WHITE-BOX TESTING: Enum Structure & Logic
+    // ==========================================
+
+    public function test_whitebox_enum_cases_and_backing_values(): void
+    {
+        $expectedValues = ['baik', 'rusak', 'hilang'];
+
+        $this->assertSame($expectedValues, ItemCondition::values());
+        $this->assertSame('baik', ItemCondition::Baik->value);
+        $this->assertSame('rusak', ItemCondition::Rusak->value);
+        $this->assertSame('hilang', ItemCondition::Hilang->value);
+
+        $this->assertSame(ItemCondition::Baik, ItemCondition::from('baik'));
+        $this->assertSame(ItemCondition::Rusak, ItemCondition::from('rusak'));
+        $this->assertSame(ItemCondition::Hilang, ItemCondition::from('hilang'));
+        $this->assertNull(ItemCondition::tryFrom('invalid_condition'));
+
+        $this->expectException(ValueError::class);
+        ItemCondition::from('hancur');
+    }
+
+    public function test_whitebox_enum_helper_methods(): void
+    {
+        // Labels
+        $this->assertSame('Baik', ItemCondition::Baik->label());
+        $this->assertSame('Rusak', ItemCondition::Rusak->label());
+        $this->assertSame('Hilang', ItemCondition::Hilang->label());
+
+        // Badge colors
+        $this->assertSame('success', ItemCondition::Baik->badgeColor());
+        $this->assertSame('warning', ItemCondition::Rusak->badgeColor());
+        $this->assertSame('danger', ItemCondition::Hilang->badgeColor());
+
+        // Borrowability
+        $this->assertTrue(ItemCondition::Baik->isBorrowable());
+        $this->assertFalse(ItemCondition::Rusak->isBorrowable());
+        $this->assertFalse(ItemCondition::Hilang->isBorrowable());
+    }
+
+    // ==========================================
+    // ⚫ BLACK-BOX TESTING: API Input & Output
+    // ==========================================
+
+    public function test_blackbox_store_item_with_valid_condition(): void
+    {
+        $payload = [
+            'name' => 'Monitor Dell 27 Inch',
+            'category_id' => $this->category->id,
+            'description' => 'Monitor kantor',
+            'stock' => 5,
+            'condition' => 'baik',
+        ];
+
+        $response = $this->actingAs($this->admin, 'sanctum')
+            ->postJson('/api/items', $payload);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.condition', 'baik')
+            ->assertJsonPath('data.name', 'Monitor Dell 27 Inch');
+
+        $this->assertDatabaseHas('items', [
+            'name' => 'Monitor Dell 27 Inch',
+            'condition' => 'baik',
+        ]);
+    }
+
+    public function test_blackbox_store_item_rejects_invalid_condition(): void
+    {
+        $payload = [
+            'name' => 'Monitor Rusak Total',
+            'category_id' => $this->category->id,
+            'stock' => 5,
+            'condition' => 'hancur_lebur',
+        ];
+
+        $response = $this->actingAs($this->admin, 'sanctum')
+            ->postJson('/api/items', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['condition']);
+    }
+
+    public function test_blackbox_update_item_condition(): void
+    {
+        $item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'stock' => 3,
+            'available_stock' => 3,
+            'condition' => ItemCondition::Baik,
+        ]);
+
+        $response = $this->actingAs($this->admin, 'sanctum')
+            ->putJson("/api/items/{$item->id}", [
+                'condition' => 'rusak',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.condition', 'rusak');
+
+        $this->assertDatabaseHas('items', [
+            'id' => $item->id,
+            'condition' => 'rusak',
+        ]);
+    }
+
+    public function test_blackbox_items_index_and_v1_serialize_condition_as_string(): void
+    {
+        Item::factory()->create([
+            'category_id' => $this->category->id,
+            'stock' => 2,
+            'available_stock' => 2,
+            'condition' => ItemCondition::Baik,
+        ]);
+
+        // Unversioned
+        $response = $this->actingAs($this->staff, 'sanctum')
+            ->getJson('/api/items');
+
+        $response->assertOk();
+        $this->assertSame('baik', $response->json('data.0.condition'));
+
+        // Versioned /v1
+        $responseV1 = $this->actingAs($this->staff, 'sanctum')
+            ->getJson('/api/v1/items');
+
+        $responseV1->assertOk();
+        $this->assertSame('baik', $responseV1->json('data.0.condition'));
+    }
+
+    // ==========================================
+    // 🔘 GREY-BOX TESTING: Eloquent Model & Persistence
+    // ==========================================
+
+    public function test_greybox_eloquent_casts_condition_attribute_to_enum(): void
+    {
+        $item = Item::create([
+            'code' => 'ITM-TEST-001',
+            'name' => 'Projector Epson',
+            'category_id' => $this->category->id,
+            'stock' => 4,
+            'available_stock' => 4,
+            'condition' => 'baik',
+        ]);
+
+        $fresh = Item::findOrFail($item->id);
+
+        $this->assertInstanceOf(ItemCondition::class, $fresh->condition);
+        $this->assertSame(ItemCondition::Baik, $fresh->condition);
+        $this->assertSame('baik', $fresh->condition->value);
+    }
+
+    public function test_greybox_assigning_enum_persists_raw_string_in_database(): void
+    {
+        $item = new Item();
+        $item->code = 'ITM-TEST-002';
+        $item->name = 'Printer HP';
+        $item->category_id = $this->category->id;
+        $item->stock = 2;
+        $item->available_stock = 2;
+        $item->condition = ItemCondition::Rusak;
+        $item->save();
+
+        $this->assertDatabaseHas('items', [
+            'id' => $item->id,
+            'condition' => 'rusak',
+        ]);
+
+        $item->condition = ItemCondition::Hilang;
+        $item->save();
+
+        $this->assertDatabaseHas('items', [
+            'id' => $item->id,
+            'condition' => 'hilang',
+        ]);
+    }
+
+    public function test_greybox_is_available_respects_condition_enum(): void
+    {
+        $goodItem = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'stock' => 5,
+            'available_stock' => 5,
+            'condition' => ItemCondition::Baik,
+        ]);
+
+        $damagedItem = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'stock' => 5,
+            'available_stock' => 5,
+            'condition' => ItemCondition::Rusak,
+        ]);
+
+        $lostItem = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'stock' => 5,
+            'available_stock' => 5,
+            'condition' => ItemCondition::Hilang,
+        ]);
+
+        $this->assertTrue($goodItem->isAvailable(1));
+        $this->assertTrue($goodItem->isAvailable(5));
+        $this->assertFalse($goodItem->isAvailable(6)); // stock exceeded
+
+        $this->assertFalse($damagedItem->isAvailable(1));
+        $this->assertFalse($lostItem->isAvailable(1));
+    }
+
+    public function test_greybox_query_scopes_filter_by_condition_enum(): void
+    {
+        Item::factory()->create([
+            'category_id' => $this->category->id,
+            'condition' => ItemCondition::Baik,
+        ]);
+        Item::factory()->create([
+            'category_id' => $this->category->id,
+            'condition' => ItemCondition::Baik,
+        ]);
+        Item::factory()->create([
+            'category_id' => $this->category->id,
+            'condition' => ItemCondition::Rusak,
+        ]);
+        Item::factory()->create([
+            'category_id' => $this->category->id,
+            'condition' => ItemCondition::Hilang,
+        ]);
+
+        $this->assertSame(2, Item::good()->count());
+        $this->assertSame(1, Item::damaged()->count());
+        $this->assertSame(1, Item::lost()->count());
+    }
+}


### PR DESCRIPTION
## Summary

This PR addresses and resolves Issue #41 (**Task R16** from Phase 4 of `docs/ROADMAP_TASKS.md`):
- **New Backed Enum (`app/Enums/ItemCondition.php`)**:
  - String-backed enum defining item conditions: `Baik = 'baik'`, `Rusak = 'rusak'`, `Hilang = 'hilang'`.
  - Helper methods:
    - `values(): array` — returns all raw backing values (`['baik', 'rusak', 'hilang']`).
    - `label(): string` — Indonesian human-readable labels (`Baik`, `Rusak`, `Hilang`).
    - `badgeColor(): string` — UI color mappings (`success`, `warning`, `danger`).
    - `isBorrowable(): bool` — validates if item is eligible for borrowing (true only for `Baik`).
- **Model Integration (`app/Models/Item.php`)**:
  - Registered `'condition' => ItemCondition::class` in `$casts`.
  - Updated `isAvailable()` to inspect enum instance or raw value.
  - Added query scopes: `scopeGood()`, `scopeDamaged()`, and `scopeLost()`.
- **Validation & Resource Layer**:
  - Replaced hardcoded string validation in `StoreItemRequest` and `UpdateItemRequest` with type-safe `Rule::enum(ItemCondition::class)`.
  - Explicitly guaranteed string conversion in `ItemResource` for 100% backward compatibility with existing clients.
- **Tri-Layer Automated Testing (`tests/Feature/ItemConditionEnumTest.php`)**:
  - ⚪ **White-box**: Enum cases, values, labels, badge colors, and `isBorrowable()`.
  - ⚫ **Black-box**: API store and update with valid conditions, 422 error on invalid conditions, and JSON string serialization on `/api/items` & `/api/v1/items`.
  - 🔘 **Grey-box**: Database persistence of enum instances, Eloquent retrieval casting, `isAvailable()` condition checks, and query scopes (`good()`, `damaged()`, `lost()`).

Closes #41
