### PR TITLE
refactor(auth): create BorrowingPolicy for granular borrowing authorization (R17)

### DIFF
--- a/app/Http/Controllers/Api/BorrowingController.php
+++ b/app/Http/Controllers/Api/BorrowingController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Enums\BorrowingStatus;
 use App\Exceptions\BorrowingException;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreBorrowingRequest;
@@ -127,8 +128,14 @@ class BorrowingController extends Controller
     /**
      * Display the specified borrowing
      */
-    public function show(Borrowing $borrowing)
+    public function show(Request $request, Borrowing $borrowing)
     {
+        if ($request->user() && $request->user()->cannot('view', $borrowing)) {
+            return response()->json([
+                'message' => 'Unauthorized. You can only view your own borrowings.',
+            ], 403);
+        }
+
         $borrowing->load(['user', 'item.category', 'approver']);
         $borrowing->updateOverdueStatus();
 
@@ -140,6 +147,12 @@ class BorrowingController extends Controller
      */
     public function return(Request $request, Borrowing $borrowing)
     {
+        if ($request->user() && $request->user()->cannot('return', $borrowing)) {
+            return response()->json([
+                'message' => 'Unauthorized. You can only return your own borrowings.',
+            ], 403);
+        }
+
         try {
             $returned = $this->borrowingService->returnBorrowing($borrowing, $request->input('return_date'));
             $returned->load(['user', 'item.category', 'approver']);
@@ -160,7 +173,7 @@ class BorrowingController extends Controller
      */
     public function approve(Request $request, Borrowing $borrowing)
     {
-        if (!$request->user()->isAdmin()) {
+        if ($request->user()->cannot('approve', $borrowing)) {
             return response()->json([
                 'message' => 'Unauthorized. Admin access required.',
             ], 403);
@@ -186,7 +199,7 @@ class BorrowingController extends Controller
      */
     public function reject(Request $request, Borrowing $borrowing)
     {
-        if (!$request->user()->isAdmin()) {
+        if ($request->user()->cannot('reject', $borrowing)) {
             return response()->json([
                 'message' => 'Unauthorized. Admin access required.',
             ], 403);
@@ -212,6 +225,12 @@ class BorrowingController extends Controller
      */
     public function update(UpdateBorrowingRequest $request, Borrowing $borrowing)
     {
+        if ($request->user() && $request->user()->cannot('update', $borrowing)) {
+            return response()->json([
+                'message' => 'Unauthorized. You cannot update this borrowing.',
+            ], 403);
+        }
+
         $statusValue = $borrowing->status instanceof \App\Enums\BorrowingStatus ? $borrowing->status->value : (string) $borrowing->status;
         if ($statusValue === \App\Enums\BorrowingStatus::Dikembalikan->value) {
             return response()->json([
@@ -231,8 +250,14 @@ class BorrowingController extends Controller
     /**
      * Remove the specified borrowing
      */
-    public function destroy(Borrowing $borrowing)
+    public function destroy(Request $request, Borrowing $borrowing)
     {
+        if ($request->user() && $request->user()->cannot('delete', $borrowing)) {
+            return response()->json([
+                'message' => 'Unauthorized. Admin access required to delete borrowings.',
+            ], 403);
+        }
+
         try {
             $this->borrowingService->deleteBorrowing($borrowing);
 
@@ -251,6 +276,12 @@ class BorrowingController extends Controller
      */
     public function extend(Request $request, Borrowing $borrowing)
     {
+        if ($request->user() && $request->user()->cannot('extend', $borrowing)) {
+            return response()->json([
+                'message' => 'Unauthorized. You can only extend your own borrowings.',
+            ], 403);
+        }
+
         $validated = $request->validate([
             'new_due_date' => 'required|date|after:due_date',
         ]);

--- a/app/Policies/BorrowingPolicy.php
+++ b/app/Policies/BorrowingPolicy.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Borrowing;
+use App\Models\User;
+
+class BorrowingPolicy
+{
+    /**
+     * Determine whether the user can view any borrowings.
+     */
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the borrowing.
+     */
+    public function view(User $user, Borrowing $borrowing): bool
+    {
+        return $user->isAdmin() || $user->id === $borrowing->user_id;
+    }
+
+    /**
+     * Determine whether the user can create borrowings.
+     */
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can update the borrowing.
+     */
+    public function update(User $user, Borrowing $borrowing): bool
+    {
+        return $user->isAdmin() || $user->id === $borrowing->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the borrowing.
+     */
+    public function delete(User $user, Borrowing $borrowing): bool
+    {
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can approve the borrowing.
+     */
+    public function approve(User $user, Borrowing $borrowing): bool
+    {
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can reject the borrowing.
+     */
+    public function reject(User $user, Borrowing $borrowing): bool
+    {
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can return the borrowed item.
+     */
+    public function return(User $user, Borrowing $borrowing): bool
+    {
+        return $user->isAdmin() || $user->id === $borrowing->user_id;
+    }
+
+    /**
+     * Determine whether the user can extend the borrowing.
+     */
+    public function extend(User $user, Borrowing $borrowing): bool
+    {
+        return $user->isAdmin() || $user->id === $borrowing->user_id;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,8 +2,11 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\ServiceProvider;
+use App\Models\Borrowing;
+use App\Policies\BorrowingPolicy;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\URL;
+use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -20,6 +23,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        // Register policies
+        Gate::policy(Borrowing::class, BorrowingPolicy::class);
+
         // Force HTTPS in production
         if ($this->app->environment('production')) {
             URL::forceScheme('https');

--- a/tests/Feature/BorrowingApprovalFlowTest.php
+++ b/tests/Feature/BorrowingApprovalFlowTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Enums\BorrowingStatus;
 use App\Jobs\SendBorrowingNotification;
 use App\Models\Borrowing;
 use App\Models\Category;
@@ -211,7 +212,7 @@ class BorrowingApprovalFlowTest extends TestCase
             ]);
 
         // State integrity: borrowing remains pending and stock untouched
-        $this->assertEquals('pending', $borrowing->fresh()->status);
+        $this->assertEquals(BorrowingStatus::Pending, $borrowing->fresh()->status);
         $this->assertNull($borrowing->fresh()->approved_by);
         $this->assertEquals(1, $this->item->fresh()->available_stock);
     }

--- a/tests/Feature/BorrowingPolicyTest.php
+++ b/tests/Feature/BorrowingPolicyTest.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\BorrowingStatus;
+use App\Enums\ItemCondition;
+use App\Models\Borrowing;
+use App\Models\Category;
+use App\Models\Item;
+use App\Models\User;
+use App\Policies\BorrowingPolicy;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Tests\TestCase;
+
+class BorrowingPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+    private User $owner;
+    private User $intruder;
+    private Item $item;
+    private Borrowing $borrowing;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create([
+            'role' => 'admin',
+            'email' => 'admin_policy@example.com',
+        ]);
+
+        $this->owner = User::factory()->create([
+            'role' => 'staff',
+            'email' => 'owner_policy@example.com',
+        ]);
+
+        $this->intruder = User::factory()->create([
+            'role' => 'staff',
+            'email' => 'intruder_policy@example.com',
+        ]);
+
+        $category = Category::factory()->create();
+        $this->item = Item::factory()->create([
+            'category_id' => $category->id,
+            'stock' => 10,
+            'available_stock' => 8,
+            'condition' => ItemCondition::Baik,
+        ]);
+
+        $this->borrowing = Borrowing::create([
+            'borrow_code' => 'BRW-POL-001',
+            'user_id' => $this->owner->id,
+            'item_id' => $this->item->id,
+            'quantity' => 2,
+            'borrow_date' => now(),
+            'due_date' => now()->addDays(5),
+            'status' => BorrowingStatus::Dipinjam,
+        ]);
+    }
+
+    // ==========================================
+    // ⚪ WHITE-BOX TESTING: Direct Policy Unit Tests
+    // ==========================================
+
+    public function test_whitebox_policy_rules_for_admin(): void
+    {
+        $policy = new BorrowingPolicy();
+
+        $this->assertTrue($policy->viewAny($this->admin));
+        $this->assertTrue($policy->view($this->admin, $this->borrowing));
+        $this->assertTrue($policy->create($this->admin));
+        $this->assertTrue($policy->update($this->admin, $this->borrowing));
+        $this->assertTrue($policy->delete($this->admin, $this->borrowing));
+        $this->assertTrue($policy->approve($this->admin, $this->borrowing));
+        $this->assertTrue($policy->reject($this->admin, $this->borrowing));
+        $this->assertTrue($policy->return($this->admin, $this->borrowing));
+        $this->assertTrue($policy->extend($this->admin, $this->borrowing));
+    }
+
+    public function test_whitebox_policy_rules_for_owner(): void
+    {
+        $policy = new BorrowingPolicy();
+
+        // Allowed for owner
+        $this->assertTrue($policy->viewAny($this->owner));
+        $this->assertTrue($policy->view($this->owner, $this->borrowing));
+        $this->assertTrue($policy->create($this->owner));
+        $this->assertTrue($policy->update($this->owner, $this->borrowing));
+        $this->assertTrue($policy->return($this->owner, $this->borrowing));
+        $this->assertTrue($policy->extend($this->owner, $this->borrowing));
+
+        // Disallowed for owner (Admin only)
+        $this->assertFalse($policy->delete($this->owner, $this->borrowing));
+        $this->assertFalse($policy->approve($this->owner, $this->borrowing));
+        $this->assertFalse($policy->reject($this->owner, $this->borrowing));
+    }
+
+    public function test_whitebox_policy_rules_for_intruder(): void
+    {
+        $policy = new BorrowingPolicy();
+
+        $this->assertTrue($policy->viewAny($this->intruder));
+        $this->assertTrue($policy->create($this->intruder));
+
+        // Disallowed for non-owner
+        $this->assertFalse($policy->view($this->intruder, $this->borrowing));
+        $this->assertFalse($policy->update($this->intruder, $this->borrowing));
+        $this->assertFalse($policy->delete($this->intruder, $this->borrowing));
+        $this->assertFalse($policy->approve($this->intruder, $this->borrowing));
+        $this->assertFalse($policy->reject($this->intruder, $this->borrowing));
+        $this->assertFalse($policy->return($this->intruder, $this->borrowing));
+        $this->assertFalse($policy->extend($this->intruder, $this->borrowing));
+    }
+
+    // ==========================================
+    // ⚫ BLACK-BOX TESTING: API Controller Authorization
+    // ==========================================
+
+    public function test_blackbox_staff_cannot_approve_or_reject_borrowing(): void
+    {
+        $pendingBorrowing = Borrowing::create([
+            'borrow_code' => 'BRW-POL-002',
+            'user_id' => $this->owner->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'borrow_date' => now(),
+            'due_date' => now()->addDays(3),
+            'status' => BorrowingStatus::Pending,
+        ]);
+
+        // Attempt approve as staff
+        $response = $this->actingAs($this->owner, 'sanctum')
+            ->postJson("/api/borrowings/{$pendingBorrowing->id}/approve");
+
+        $response->assertStatus(403)
+            ->assertJson(['message' => 'Unauthorized. Admin access required.']);
+
+        // Attempt reject as staff
+        $responseReject = $this->actingAs($this->owner, 'sanctum')
+            ->postJson("/api/borrowings/{$pendingBorrowing->id}/reject");
+
+        $responseReject->assertStatus(403)
+            ->assertJson(['message' => 'Unauthorized. Admin access required.']);
+    }
+
+    public function test_blackbox_intruder_cannot_return_or_extend_borrowing(): void
+    {
+        // Intruder tries to return owner's borrowing
+        $responseReturn = $this->actingAs($this->intruder, 'sanctum')
+            ->postJson("/api/borrowings/{$this->borrowing->id}/return");
+
+        $responseReturn->assertStatus(403)
+            ->assertJson(['message' => 'Unauthorized. You can only return your own borrowings.']);
+
+        // Intruder tries to extend owner's borrowing
+        $responseExtend = $this->actingAs($this->intruder, 'sanctum')
+            ->postJson("/api/borrowings/{$this->borrowing->id}/extend", [
+                'new_due_date' => now()->addDays(10)->format('Y-m-d'),
+            ]);
+
+        $responseExtend->assertStatus(403)
+            ->assertJson(['message' => 'Unauthorized. You can only extend your own borrowings.']);
+    }
+
+    public function test_blackbox_intruder_cannot_view_or_update_or_delete_borrowing(): void
+    {
+        // View
+        $responseView = $this->actingAs($this->intruder, 'sanctum')
+            ->getJson("/api/borrowings/{$this->borrowing->id}");
+
+        $responseView->assertStatus(403)
+            ->assertJson(['message' => 'Unauthorized. You can only view your own borrowings.']);
+
+        // Update
+        $responseUpdate = $this->actingAs($this->intruder, 'sanctum')
+            ->putJson("/api/borrowings/{$this->borrowing->id}", [
+                'notes' => 'Hacked notes',
+            ]);
+
+        $responseUpdate->assertStatus(403)
+            ->assertJson(['message' => 'Unauthorized. You cannot update this borrowing.']);
+
+        // Delete
+        $responseDelete = $this->actingAs($this->intruder, 'sanctum')
+            ->deleteJson("/api/borrowings/{$this->borrowing->id}");
+
+        $responseDelete->assertStatus(403)
+            ->assertJson(['message' => 'Unauthorized. Admin access required to delete borrowings.']);
+    }
+
+    public function test_blackbox_owner_can_view_and_return_own_borrowing(): void
+    {
+        // Owner views
+        $responseView = $this->actingAs($this->owner, 'sanctum')
+            ->getJson("/api/borrowings/{$this->borrowing->id}");
+
+        $responseView->assertOk()
+            ->assertJsonPath('data.id', $this->borrowing->id);
+
+        // Owner returns
+        $responseReturn = $this->actingAs($this->owner, 'sanctum')
+            ->postJson("/api/borrowings/{$this->borrowing->id}/return");
+
+        $responseReturn->assertOk()
+            ->assertJson(['message' => 'Item returned successfully']);
+    }
+
+    public function test_blackbox_admin_can_perform_all_borrowing_actions(): void
+    {
+        $pendingBorrowing = Borrowing::create([
+            'borrow_code' => 'BRW-POL-003',
+            'user_id' => $this->owner->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'borrow_date' => now(),
+            'due_date' => now()->addDays(3),
+            'status' => BorrowingStatus::Pending,
+        ]);
+
+        // Admin approves
+        $responseApprove = $this->actingAs($this->admin, 'sanctum')
+            ->postJson("/api/borrowings/{$pendingBorrowing->id}/approve");
+
+        $responseApprove->assertOk()
+            ->assertJson(['message' => 'Borrowing approved successfully']);
+
+        // Admin extends
+        $responseExtend = $this->actingAs($this->admin, 'sanctum')
+            ->postJson("/api/borrowings/{$pendingBorrowing->id}/extend", [
+                'new_due_date' => now()->addDays(12)->format('Y-m-d'),
+            ]);
+
+        $responseExtend->assertOk()
+            ->assertJson(['message' => 'Borrowing extended successfully']);
+
+        // Admin views
+        $responseView = $this->actingAs($this->admin, 'sanctum')
+            ->getJson("/api/borrowings/{$pendingBorrowing->id}");
+
+        $responseView->assertOk();
+    }
+
+    // ==========================================
+    // 🔘 GREY-BOX TESTING: Gate & Model Helper Resolution
+    // ==========================================
+
+    public function test_greybox_gate_policy_resolution(): void
+    {
+        $resolvedPolicy = Gate::getPolicyFor(Borrowing::class);
+
+        $this->assertInstanceOf(BorrowingPolicy::class, $resolvedPolicy);
+    }
+
+    public function test_greybox_user_can_and_cannot_gate_checks(): void
+    {
+        $this->assertTrue($this->admin->can('approve', $this->borrowing));
+        $this->assertTrue($this->admin->can('delete', $this->borrowing));
+
+        $this->assertTrue($this->owner->cannot('approve', $this->borrowing));
+        $this->assertTrue($this->owner->cannot('delete', $this->borrowing));
+        $this->assertTrue($this->owner->can('return', $this->borrowing));
+        $this->assertTrue($this->owner->can('extend', $this->borrowing));
+
+        $this->assertTrue($this->intruder->cannot('return', $this->borrowing));
+        $this->assertTrue($this->intruder->cannot('extend', $this->borrowing));
+        $this->assertTrue($this->intruder->cannot('view', $this->borrowing));
+    }
+}


### PR DESCRIPTION
## Summary

This PR addresses and resolves Issue #43 (**Task R17** from Phase 4 of `docs/ROADMAP_TASKS.md`):
- **New Policy (`app/Policies/BorrowingPolicy.php`)**:
  - Encapsulates granular authorization rules for borrowings based on RBAC and resource ownership:
    - `viewAny()` & `create()`: Authenticated users.
    - `view()`, `update()`, `return()`, `extend()`: Admin or borrowing owner (`$user->id === $borrowing->user_id`).
    - `approve()`, `reject()`, `delete()`: Strictly Admin (`$user->isAdmin()`).
- **Policy Registration (`app/Providers/AppServiceProvider.php`)**:
  - Registered `Gate::policy(Borrowing::class, BorrowingPolicy::class)` in `boot()`.
- **Controller Enforcement (`app/Http/Controllers/Api/BorrowingController.php`)**:
  - Integrated policy enforcement via `$request->user()->cannot(...)` on `show`, `approve`, `reject`, `update`, `destroy`, `return`, and `extend`, ensuring uniform 403 Forbidden responses.
- **Tri-Layer Automated Testing (`tests/Feature/BorrowingPolicyTest.php`)**:
  - ⚪ **White-box**: Direct policy method evaluations for `admin`, `owner`, and `intruder` (non-owner staff).
  - ⚫ **Black-box**: API endpoints reject unauthorized actions with HTTP 403 Forbidden and allow authorized actions for Admin and Owner.
  - 🔘 **Grey-box**: Validated Gate policy resolution and Eloquent `$user->can()` / `$user->cannot()` helper integration.

Closes #43
