### PR TITLE
refactor(auth): create ItemPolicy for centralized item authorization (R18)

### DIFF
--- a/app/Http/Controllers/Api/ItemController.php
+++ b/app/Http/Controllers/Api/ItemController.php
@@ -151,8 +151,14 @@ class ItemController extends Controller
     /**
      * Remove the specified item
      */
-    public function destroy(Item $item)
+    public function destroy(Request $request, Item $item)
     {
+        if ($request->user() && $request->user()->cannot('delete', $item)) {
+            return response()->json([
+                'message' => 'Unauthorized. Admin access required.',
+            ], 403);
+        }
+
         try {
             $this->itemService->deleteItem($item);
 
@@ -171,6 +177,12 @@ class ItemController extends Controller
      */
     public function bulkDelete(Request $request)
     {
+        if ($request->user() && $request->user()->cannot('bulkDelete', Item::class)) {
+            return response()->json([
+                'message' => 'Unauthorized. Admin access required.',
+            ], 403);
+        }
+
         $validated = $request->validate([
             'ids' => 'required|array|min:1',
             'ids.*' => 'exists:items,id',

--- a/app/Http/Requests/StoreItemRequest.php
+++ b/app/Http/Requests/StoreItemRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use App\Enums\ItemCondition;
+use App\Models\Item;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -13,7 +14,7 @@ class StoreItemRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return $this->user()?->isAdmin() ?? false;
+        return $this->user()?->can('create', Item::class) ?? false;
     }
 
     /**

--- a/app/Http/Requests/UpdateItemRequest.php
+++ b/app/Http/Requests/UpdateItemRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use App\Enums\ItemCondition;
+use App\Models\Item;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -13,7 +14,12 @@ class UpdateItemRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return $this->user()?->isAdmin() ?? false;
+        $item = $this->route('item');
+        if ($item instanceof Item) {
+            return $this->user()?->can('update', $item) ?? false;
+        }
+
+        return $this->user()?->can('update', Item::class) ?? false;
     }
 
     /**

--- a/app/Policies/ItemPolicy.php
+++ b/app/Policies/ItemPolicy.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Item;
+use App\Models\User;
+
+class ItemPolicy
+{
+    /**
+     * Determine whether the user can view any items.
+     */
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the item.
+     */
+    public function view(User $user, Item $item): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can create items.
+     */
+    public function create(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can update the item.
+     */
+    public function update(User $user, Item $item): bool
+    {
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can delete the item.
+     */
+    public function delete(User $user, Item $item): bool
+    {
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can bulk delete items.
+     */
+    public function bulkDelete(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,7 +3,9 @@
 namespace App\Providers;
 
 use App\Models\Borrowing;
+use App\Models\Item;
 use App\Policies\BorrowingPolicy;
+use App\Policies\ItemPolicy;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
@@ -25,6 +27,7 @@ class AppServiceProvider extends ServiceProvider
     {
         // Register policies
         Gate::policy(Borrowing::class, BorrowingPolicy::class);
+        Gate::policy(Item::class, ItemPolicy::class);
 
         // Force HTTPS in production
         if ($this->app->environment('production')) {

--- a/tests/Feature/ItemPolicyTest.php
+++ b/tests/Feature/ItemPolicyTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\ItemCondition;
+use App\Models\Category;
+use App\Models\Item;
+use App\Models\User;
+use App\Policies\ItemPolicy;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Tests\TestCase;
+
+class ItemPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+    private User $staff;
+    private Category $category;
+    private Item $item;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create([
+            'role' => 'admin',
+            'email' => 'admin_item_policy@example.com',
+        ]);
+
+        $this->staff = User::factory()->create([
+            'role' => 'staff',
+            'email' => 'staff_item_policy@example.com',
+        ]);
+
+        $this->category = Category::factory()->create();
+
+        $this->item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'stock' => 10,
+            'available_stock' => 10,
+            'condition' => ItemCondition::Baik,
+        ]);
+    }
+
+    // ==========================================
+    // ⚪ WHITE-BOX TESTING: Direct Policy Unit Tests
+    // ==========================================
+
+    public function test_whitebox_item_policy_rules_for_admin(): void
+    {
+        $policy = new ItemPolicy();
+
+        $this->assertTrue($policy->viewAny($this->admin));
+        $this->assertTrue($policy->view($this->admin, $this->item));
+        $this->assertTrue($policy->create($this->admin));
+        $this->assertTrue($policy->update($this->admin, $this->item));
+        $this->assertTrue($policy->delete($this->admin, $this->item));
+        $this->assertTrue($policy->bulkDelete($this->admin));
+    }
+
+    public function test_whitebox_item_policy_rules_for_staff(): void
+    {
+        $policy = new ItemPolicy();
+
+        // Allowed for staff (read-only)
+        $this->assertTrue($policy->viewAny($this->staff));
+        $this->assertTrue($policy->view($this->staff, $this->item));
+
+        // Disallowed for staff (mutations)
+        $this->assertFalse($policy->create($this->staff));
+        $this->assertFalse($policy->update($this->staff, $this->item));
+        $this->assertFalse($policy->delete($this->staff, $this->item));
+        $this->assertFalse($policy->bulkDelete($this->staff));
+    }
+
+    // ==========================================
+    // ⚫ BLACK-BOX TESTING: API Controller & Requests
+    // ==========================================
+
+    public function test_blackbox_staff_cannot_create_item(): void
+    {
+        $response = $this->actingAs($this->staff, 'sanctum')
+            ->postJson('/api/items', [
+                'name' => 'Unauthorized Item',
+                'category_id' => $this->category->id,
+                'stock' => 5,
+                'condition' => 'baik',
+            ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_blackbox_staff_cannot_update_item(): void
+    {
+        $response = $this->actingAs($this->staff, 'sanctum')
+            ->putJson("/api/items/{$this->item->id}", [
+                'name' => 'Tampered Item Name',
+            ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_blackbox_staff_cannot_delete_item(): void
+    {
+        $response = $this->actingAs($this->staff, 'sanctum')
+            ->deleteJson("/api/items/{$this->item->id}");
+
+        $response->assertStatus(403)
+            ->assertJson(['message' => 'Unauthorized. Admin access required.']);
+    }
+
+    public function test_blackbox_staff_cannot_bulk_delete_items(): void
+    {
+        $secondItem = Item::factory()->create(['category_id' => $this->category->id]);
+
+        $response = $this->actingAs($this->staff, 'sanctum')
+            ->deleteJson('/api/items/bulk-delete', [
+                'ids' => [$this->item->id, $secondItem->id],
+            ]);
+
+        $response->assertStatus(403)
+            ->assertJson(['message' => 'Unauthorized. Admin access required.']);
+    }
+
+    public function test_blackbox_staff_can_view_items_list_and_detail(): void
+    {
+        // View list
+        $responseList = $this->actingAs($this->staff, 'sanctum')
+            ->getJson('/api/items');
+
+        $responseList->assertOk();
+
+        // View detail
+        $responseDetail = $this->actingAs($this->staff, 'sanctum')
+            ->getJson("/api/items/{$this->item->id}");
+
+        $responseDetail->assertOk()
+            ->assertJsonPath('data.id', $this->item->id);
+    }
+
+    public function test_blackbox_admin_can_perform_all_item_actions(): void
+    {
+        // Admin creates
+        $responseCreate = $this->actingAs($this->admin, 'sanctum')
+            ->postJson('/api/items', [
+                'name' => 'Admin Created Item',
+                'category_id' => $this->category->id,
+                'stock' => 10,
+                'condition' => 'baik',
+            ]);
+
+        $responseCreate->assertStatus(201);
+        $createdId = $responseCreate->json('data.id');
+
+        // Admin updates
+        $responseUpdate = $this->actingAs($this->admin, 'sanctum')
+            ->putJson("/api/items/{$createdId}", [
+                'name' => 'Admin Updated Item',
+            ]);
+
+        $responseUpdate->assertOk()
+            ->assertJsonPath('data.name', 'Admin Updated Item');
+
+        // Admin deletes
+        $responseDelete = $this->actingAs($this->admin, 'sanctum')
+            ->deleteJson("/api/items/{$createdId}");
+
+        $responseDelete->assertOk()
+            ->assertJson(['message' => 'Item deleted successfully']);
+    }
+
+    // ==========================================
+    // 🔘 GREY-BOX TESTING: Gate Resolution & Helpers
+    // ==========================================
+
+    public function test_greybox_gate_resolves_item_policy(): void
+    {
+        $resolvedPolicy = Gate::getPolicyFor(Item::class);
+
+        $this->assertInstanceOf(ItemPolicy::class, $resolvedPolicy);
+    }
+
+    public function test_greybox_user_can_and_cannot_helpers_for_item(): void
+    {
+        $this->assertTrue($this->admin->can('create', Item::class));
+        $this->assertTrue($this->admin->can('update', $this->item));
+        $this->assertTrue($this->admin->can('delete', $this->item));
+        $this->assertTrue($this->admin->can('bulkDelete', Item::class));
+
+        $this->assertTrue($this->staff->cannot('create', Item::class));
+        $this->assertTrue($this->staff->cannot('update', $this->item));
+        $this->assertTrue($this->staff->cannot('delete', $this->item));
+        $this->assertTrue($this->staff->cannot('bulkDelete', Item::class));
+        $this->assertTrue($this->staff->can('view', $this->item));
+        $this->assertTrue($this->staff->can('viewAny', Item::class));
+    }
+}


### PR DESCRIPTION
## Summary

This PR addresses and resolves Issue #45 (**Task R18** from Phase 4 of `docs/ROADMAP_TASKS.md`):
- **New Policy (`app/Policies/ItemPolicy.php`)**:
  - Centralized authorization rules for item management:
    - `viewAny()` & `view()`: Authenticated users can browse items.
    - `create()`, `update()`, `delete()`, `bulkDelete()`: Strictly restricted to Admin users (`$user->isAdmin()`).
- **Policy Registration (`app/Providers/AppServiceProvider.php`)**:
  - Registered `Gate::policy(Item::class, ItemPolicy::class)` in `boot()`.
- **Controller & Request Enforcement**:
  - In `ItemController.php`: Enforced policy checks via `$request->user()->cannot(...)` on `destroy` and `bulkDelete`, returning consistent 403 Forbidden responses.
  - In `StoreItemRequest.php` & `UpdateItemRequest.php`: Delegated `authorize()` checks to `$this->user()?->can(...)`.
- **Tri-Layer Automated Testing (`tests/Feature/ItemPolicyTest.php`)**:
  - ⚪ **White-box**: Direct policy method evaluations for `admin` vs `staff`.
  - ⚫ **Black-box**: API endpoints reject non-admin modification attempts (`POST /api/items`, `PUT /api/items/{id}`, `DELETE /api/items/{id}`, `DELETE /api/items/bulk-delete`) with 403 Forbidden while allowing read access (200 OK) and full admin operations (200/201 OK).
  - 🔘 **Grey-box**: Validated Gate policy resolution and Eloquent `$user->can()` / `$user->cannot()` helpers.

Closes #45
