### PR TITLE
feat(borrowing): add rejection notes on admin reject borrowing request (F4)

### DIFF
--- a/app/Http/Controllers/Api/BorrowingController.php
+++ b/app/Http/Controllers/Api/BorrowingController.php
@@ -205,8 +205,12 @@ class BorrowingController extends Controller
             ], 403);
         }
 
+        $validated = $request->validate([
+            'rejection_note' => 'nullable|string|max:500',
+        ]);
+
         try {
-            $rejected = $this->borrowingService->rejectBorrowing($borrowing);
+            $rejected = $this->borrowingService->rejectBorrowing($borrowing, $validated['rejection_note'] ?? null);
             $rejected->load(['user', 'item.category', 'approver']);
 
             return (new BorrowingResource($rejected))

--- a/app/Http/Resources/BorrowingResource.php
+++ b/app/Http/Resources/BorrowingResource.php
@@ -32,6 +32,7 @@ class BorrowingResource extends JsonResource
             'return_date' => $this->return_date?->format('Y-m-d'),
             'status' => $statusValue,
             'notes' => $this->notes,
+            'rejection_note' => $this->rejection_note,
             'approved_by' => $this->approved_by,
             'approved_at' => $this->approved_at?->format('Y-m-d H:i:s'),
             'created_at' => $this->created_at?->format('Y-m-d H:i:s'),

--- a/app/Models/Borrowing.php
+++ b/app/Models/Borrowing.php
@@ -29,6 +29,7 @@ class Borrowing extends Model
         'return_date',
         'status',
         'notes',
+        'rejection_note',
         'approved_by',
         'approved_at',
     ];

--- a/app/Services/BorrowingService.php
+++ b/app/Services/BorrowingService.php
@@ -149,14 +149,14 @@ class BorrowingService
      *
      * @throws BorrowingException
      */
-    public function rejectBorrowing(Borrowing $borrowing): Borrowing
+    public function rejectBorrowing(Borrowing $borrowing, ?string $rejectionNote = null): Borrowing
     {
         $status = $this->getStatusValue($borrowing);
         if ($borrowing->approved_by !== null || in_array($status, ['approved', 'dipinjam', 'dikembalikan', 'terlambat', 'ditolak', 'rejected'])) {
             throw new BorrowingException('Peminjaman sudah diproses.', 400);
         }
 
-        return DB::transaction(function () use ($borrowing) {
+        return DB::transaction(function () use ($borrowing, $rejectionNote) {
             /** @var Borrowing $lockedBorrowing */
             $lockedBorrowing = Borrowing::lockForUpdate()->findOrFail($borrowing->id);
 
@@ -166,6 +166,7 @@ class BorrowingService
             }
 
             $lockedBorrowing->status = BorrowingStatus::Rejected;
+            $lockedBorrowing->rejection_note = $rejectionNote;
             $lockedBorrowing->save();
 
             $lockedBorrowing->load(['user', 'item', 'approver']);

--- a/database/migrations/2026_01_09_000001_add_rejection_note_to_borrowings_table.php
+++ b/database/migrations/2026_01_09_000001_add_rejection_note_to_borrowings_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('borrowings', function (Blueprint $table) {
+            if (!Schema::hasColumn('borrowings', 'rejection_note')) {
+                $table->text('rejection_note')->nullable()->after('notes');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('borrowings', function (Blueprint $table) {
+            if (Schema::hasColumn('borrowings', 'rejection_note')) {
+                $table->dropColumn('rejection_note');
+            }
+        });
+    }
+};

--- a/tests/Feature/BorrowingRejectWithNoteTest.php
+++ b/tests/Feature/BorrowingRejectWithNoteTest.php
@@ -1,0 +1,320 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\BorrowingStatus;
+use App\Enums\ItemCondition;
+use App\Exceptions\BorrowingException;
+use App\Models\Borrowing;
+use App\Models\Category;
+use App\Models\Item;
+use App\Models\User;
+use App\Services\BorrowingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class BorrowingRejectWithNoteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $staff;
+    protected User $admin;
+    protected Category $category;
+    protected Item $item;
+    protected BorrowingService $borrowingService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Queue::fake();
+
+        $this->staff = User::factory()->create(['role' => 'staff']);
+        $this->admin = User::factory()->create(['role' => 'admin']);
+
+        $this->category = Category::factory()->create(['name' => 'Elektronik']);
+        $this->item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'name' => 'Lenovo ThinkPad X1',
+            'code' => 'ITM-TEST-002',
+            'stock' => 10,
+            'available_stock' => 10,
+            'condition' => ItemCondition::Baik,
+        ]);
+
+        $this->borrowingService = app(BorrowingService::class);
+    }
+
+    /* =========================================================================
+     * ⚪ WHITE-BOX TESTING (Direct Service Logic, Rejection Notes & Boundaries)
+     * ========================================================================= */
+
+    public function test_whitebox_reject_borrowing_saves_rejection_note(): void
+    {
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 2,
+            'status' => BorrowingStatus::Pending,
+        ]);
+
+        $rejectionReason = 'Barang sedang dipersiapkan untuk audit tahunan.';
+        $rejected = $this->borrowingService->rejectBorrowing($borrowing, $rejectionReason);
+
+        $this->assertInstanceOf(Borrowing::class, $rejected);
+        $this->assertEquals(BorrowingStatus::Rejected, $rejected->status);
+        $this->assertEquals($rejectionReason, $rejected->rejection_note);
+
+        // Stock must remain unchanged
+        $this->assertEquals(10, $this->item->fresh()->available_stock);
+    }
+
+    public function test_whitebox_reject_borrowing_without_note_sets_rejection_note_null(): void
+    {
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'status' => BorrowingStatus::Pending,
+        ]);
+
+        $rejected = $this->borrowingService->rejectBorrowing($borrowing);
+
+        $this->assertEquals(BorrowingStatus::Rejected, $rejected->status);
+        $this->assertNull($rejected->rejection_note);
+        $this->assertEquals(10, $this->item->fresh()->available_stock);
+    }
+
+    public function test_whitebox_reject_borrowing_throws_when_already_processed(): void
+    {
+        $alreadyApproved = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'status' => BorrowingStatus::Dipinjam,
+            'approved_by' => $this->admin->id,
+        ]);
+
+        $this->expectException(BorrowingException::class);
+        $this->expectExceptionMessage('Peminjaman sudah diproses.');
+
+        $this->borrowingService->rejectBorrowing($alreadyApproved, 'Tidak bisa ditolak karena sudah disetujui');
+    }
+
+    public function test_whitebox_reject_borrowing_throws_when_already_rejected(): void
+    {
+        $alreadyRejected = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'status' => BorrowingStatus::Rejected,
+            'rejection_note' => 'Penolakan pertama',
+        ]);
+
+        $this->expectException(BorrowingException::class);
+        $this->expectExceptionMessage('Peminjaman sudah diproses.');
+
+        $this->borrowingService->rejectBorrowing($alreadyRejected, 'Penolakan kedua');
+    }
+
+    /* =========================================================================
+     * ⚫ BLACK-BOX TESTING (API HTTP Endpoints, Validation & Permissions)
+     * ========================================================================= */
+
+    public function test_blackbox_admin_can_reject_borrowing_with_rejection_note(): void
+    {
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 2,
+            'status' => BorrowingStatus::Pending,
+        ]);
+
+        Sanctum::actingAs($this->admin);
+
+        $response = $this->postJson("/api/borrowings/{$borrowing->id}/reject", [
+            'rejection_note' => 'Unit tidak tersedia untuk peminjaman luar kota.',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'Borrowing rejected successfully',
+                'data' => [
+                    'id' => $borrowing->id,
+                    'status' => 'rejected',
+                    'rejection_note' => 'Unit tidak tersedia untuk peminjaman luar kota.',
+                ],
+            ]);
+    }
+
+    public function test_blackbox_admin_can_reject_borrowing_without_rejection_note(): void
+    {
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'status' => BorrowingStatus::Pending,
+        ]);
+
+        Sanctum::actingAs($this->admin);
+
+        $response = $this->postJson("/api/borrowings/{$borrowing->id}/reject", []);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'Borrowing rejected successfully',
+                'data' => [
+                    'id' => $borrowing->id,
+                    'status' => 'rejected',
+                    'rejection_note' => null,
+                ],
+            ]);
+    }
+
+    public function test_blackbox_staff_cannot_reject_borrowing(): void
+    {
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'status' => BorrowingStatus::Pending,
+        ]);
+
+        Sanctum::actingAs($this->staff);
+
+        $response = $this->postJson("/api/borrowings/{$borrowing->id}/reject", [
+            'rejection_note' => 'Staff coba menolak',
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_blackbox_unauthenticated_request_cannot_reject(): void
+    {
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'status' => BorrowingStatus::Pending,
+        ]);
+
+        $response = $this->postJson("/api/borrowings/{$borrowing->id}/reject", [
+            'rejection_note' => 'Guest coba menolak',
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_blackbox_reject_validates_rejection_note_max_length(): void
+    {
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'status' => BorrowingStatus::Pending,
+        ]);
+
+        Sanctum::actingAs($this->admin);
+
+        $longNote = str_repeat('A', 501);
+
+        $response = $this->postJson("/api/borrowings/{$borrowing->id}/reject", [
+            'rejection_note' => $longNote,
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['rejection_note']);
+    }
+
+    /* =========================================================================
+     * 🔘 GREY-BOX TESTING (Database State & Invariance Verification)
+     * ========================================================================= */
+
+    public function test_greybox_database_persistence_and_stock_invariance_on_rejection(): void
+    {
+        $initialStock = $this->item->available_stock;
+
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 3,
+            'status' => BorrowingStatus::Pending,
+        ]);
+
+        Sanctum::actingAs($this->admin);
+
+        $response = $this->postJson("/api/borrowings/{$borrowing->id}/reject", [
+            'rejection_note' => 'Alasan spesifik penolakan barang.',
+        ]);
+
+        $response->assertStatus(200);
+
+        // Verify database persistence
+        $this->assertDatabaseHas('borrowings', [
+            'id' => $borrowing->id,
+            'status' => 'rejected',
+            'rejection_note' => 'Alasan spesifik penolakan barang.',
+        ]);
+
+        // Stock in database MUST NOT change
+        $this->assertDatabaseHas('items', [
+            'id' => $this->item->id,
+            'available_stock' => $initialStock,
+        ]);
+    }
+
+    public function test_greybox_cannot_approve_already_rejected_borrowing(): void
+    {
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 2,
+            'status' => BorrowingStatus::Rejected,
+            'rejection_note' => 'Sudah ditolak sebelumnya.',
+        ]);
+
+        Sanctum::actingAs($this->admin);
+
+        $approveResponse = $this->postJson("/api/borrowings/{$borrowing->id}/approve");
+
+        $approveResponse->assertStatus(400)
+            ->assertJson([
+                'message' => 'Peminjaman sudah diproses atau sudah disetujui.',
+            ]);
+
+        // Status remains rejected
+        $this->assertDatabaseHas('borrowings', [
+            'id' => $borrowing->id,
+            'status' => 'rejected',
+            'rejection_note' => 'Sudah ditolak sebelumnya.',
+        ]);
+    }
+
+    public function test_greybox_cannot_reject_twice_via_api(): void
+    {
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'status' => BorrowingStatus::Pending,
+        ]);
+
+        Sanctum::actingAs($this->admin);
+
+        // First reject: 200
+        $res1 = $this->postJson("/api/borrowings/{$borrowing->id}/reject", [
+            'rejection_note' => 'Pertama',
+        ]);
+        $res1->assertStatus(200);
+
+        // Second reject: 400
+        $res2 = $this->postJson("/api/borrowings/{$borrowing->id}/reject", [
+            'rejection_note' => 'Kedua',
+        ]);
+        $res2->assertStatus(400)
+            ->assertJson([
+                'message' => 'Peminjaman sudah diproses.',
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary of Changes

Closes #51

### Problem
Previously, when an administrator rejected a borrowing request (`POST /api/borrowings/{id}/reject`), the status was updated to `rejected`, but there was no mechanism to provide or persist a rejection reason/note explaining why the request was turned down (F4 in Roadmap).

### Solution
1. **Migration**:
   - Created `2026_01_09_000001_add_rejection_note_to_borrowings_table.php` adding nullable `rejection_note` text column after `notes` in `borrowings` table.
2. **Model**:
   - Added `'rejection_note'` to `$fillable` in `Borrowing.php`.
3. **BorrowingService**:
   - Updated `rejectBorrowing(Borrowing $borrowing, ?string $rejectionNote = null): Borrowing` to persist the rejection note atomically under pessimistic locking.
4. **Controller & Validation**:
   - In `BorrowingController::reject()`, added request validation for `'rejection_note' => 'nullable|string|max:500'` and forwarded it to the service.
5. **API Resource**:
   - Exposed `'rejection_note' => $this->rejection_note` in `BorrowingResource.php`.
6. **Tri-Layer Testing**:
   - Created `BorrowingRejectWithNoteTest.php` covering White-Box, Black-Box (HTTP status codes, validation, authorization), and Grey-Box (database state and stock invariance).
7. **Roadmap**:
   - Updated `docs/ROADMAP_TASKS.md` marking F4 as complete.

### Testing Checklist
- [x] Tri-Layer suite `BorrowingRejectWithNoteTest`: 12 tests, 29 assertions passed.
- [x] Full borrowing test suite: 102 tests, 490 assertions passed (`OK (102 tests, 490 assertions)`).
- [x] Vite asset build completed cleanly (`npm run build`).
