### PR TITLE
feat(notification): implement email and database notifications on approval and rejection (F5)

### DIFF
--- a/app/Jobs/SendBorrowingNotification.php
+++ b/app/Jobs/SendBorrowingNotification.php
@@ -41,7 +41,7 @@ class SendBorrowingNotification implements ShouldQueue
                 $user->notify(new \App\Notifications\BorrowingApprovedNotification($this->borrowing));
                 break;
             case 'rejected':
-                // Implement if rejection notification exists
+                $user->notify(new \App\Notifications\BorrowingRejectedNotification($this->borrowing));
                 break;
             case 'reminder':
                 // Implement reminder notification

--- a/app/Notifications/BorrowingRejectedNotification.php
+++ b/app/Notifications/BorrowingRejectedNotification.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Borrowing;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class BorrowingRejectedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public Borrowing $borrowing)
+    {
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        /** @var \App\Models\Borrowing&\stdClass $borrowingWithId */
+        $borrowingWithId = $this->borrowing;
+        /** @var \Carbon\Carbon|null $borrowDate */
+        $borrowDate = $this->borrowing->borrow_date;
+        $borrowDateFormatted = $borrowDate ? $borrowDate->format('d/m/Y') : '-';
+
+        $mail = (new MailMessage)
+            ->subject('Peminjaman Ditolak - ' . $this->borrowing->code)
+            ->greeting('Halo ' . $notifiable->name . ',')
+            ->line('Mohon maaf, permohonan peminjaman barang Anda telah ditolak.')
+            ->line('**Detail Peminjaman:**')
+            ->line('Kode Peminjaman: ' . $this->borrowing->code)
+            ->line('Barang: ' . ($this->borrowing->item?->name ?? 'Barang'))
+            ->line('Jumlah: ' . $this->borrowing->quantity)
+            ->line('Tanggal Pengajuan: ' . $borrowDateFormatted);
+
+        if (!empty($this->borrowing->rejection_note)) {
+            $mail->line('**Alasan Penolakan:** ' . $this->borrowing->rejection_note);
+        }
+
+        return $mail
+            ->action('Lihat Detail', url('/borrowings/' . $borrowingWithId->id))
+            ->line('Silakan hubungi administrator jika Anda memerlukan informasi lebih lanjut.');
+    }
+
+    /**
+     * Get the array representation of the notification for database channel.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        /** @var \App\Models\Borrowing&\stdClass $borrowingWithId */
+        $borrowingWithId = $this->borrowing;
+
+        return [
+            'type' => 'borrowing_rejected',
+            'borrowing_id' => $borrowingWithId->id,
+            'borrowing_code' => $this->borrowing->code,
+            'item_name' => $this->borrowing->item?->name ?? 'Barang',
+            'quantity' => $this->borrowing->quantity,
+            'rejection_note' => $this->borrowing->rejection_note,
+            'message' => 'Permohonan peminjaman Anda untuk ' . ($this->borrowing->item?->name ?? 'barang') . ' telah ditolak.',
+        ];
+    }
+}

--- a/app/Services/BorrowingService.php
+++ b/app/Services/BorrowingService.php
@@ -156,7 +156,7 @@ class BorrowingService
             throw new BorrowingException('Peminjaman sudah diproses.', 400);
         }
 
-        return DB::transaction(function () use ($borrowing, $rejectionNote) {
+        $rejectedBorrowing = DB::transaction(function () use ($borrowing, $rejectionNote) {
             /** @var Borrowing $lockedBorrowing */
             $lockedBorrowing = Borrowing::lockForUpdate()->findOrFail($borrowing->id);
 
@@ -173,6 +173,16 @@ class BorrowingService
 
             return $lockedBorrowing;
         });
+
+        // Dispatch queue job for notification
+        try {
+            SendBorrowingNotification::dispatch($rejectedBorrowing, 'rejected');
+        } catch (\Throwable $e) {
+            // Log error but don't fail the rejection
+            report($e);
+        }
+
+        return $rejectedBorrowing;
     }
 
     /**

--- a/tests/Feature/BorrowingNotificationTest.php
+++ b/tests/Feature/BorrowingNotificationTest.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\BorrowingStatus;
+use App\Enums\ItemCondition;
+use App\Jobs\SendBorrowingNotification;
+use App\Models\Borrowing;
+use App\Models\Category;
+use App\Models\Item;
+use App\Models\User;
+use App\Notifications\BorrowingApprovedNotification;
+use App\Notifications\BorrowingRejectedNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Queue;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class BorrowingNotificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $staff;
+    protected User $admin;
+    protected Category $category;
+    protected Item $item;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->staff = User::factory()->create(['role' => 'staff']);
+        $this->admin = User::factory()->create(['role' => 'admin']);
+
+        $this->category = Category::factory()->create(['name' => 'Elektronik']);
+        $this->item = Item::factory()->create([
+            'category_id' => $this->category->id,
+            'name' => 'Monitor Dell UltraSharp',
+            'code' => 'ITM-NOTIF-001',
+            'stock' => 10,
+            'available_stock' => 10,
+            'condition' => ItemCondition::Baik,
+        ]);
+    }
+
+    /* =========================================================================
+     * ⚪ WHITE-BOX TESTING (Notification Classes & Queue Job Handling)
+     * ========================================================================= */
+
+    public function test_whitebox_job_handles_approved_notification(): void
+    {
+        Notification::fake();
+
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'status' => BorrowingStatus::Dipinjam,
+            'approved_by' => $this->admin->id,
+        ]);
+
+        $job = new SendBorrowingNotification($borrowing, 'approved');
+        $job->handle();
+
+        Notification::assertSentTo($this->staff, BorrowingApprovedNotification::class, function ($notification) use ($borrowing) {
+            $mailData = $notification->toMail($this->staff);
+            $arrayData = $notification->toArray($this->staff);
+
+            $this->assertStringContainsString($borrowing->code, $mailData->subject);
+            $this->assertEquals('borrowing_approved', $arrayData['type']);
+            $this->assertEquals($borrowing->id, $arrayData['borrowing_id']);
+
+            return true;
+        });
+    }
+
+    public function test_whitebox_job_handles_rejected_notification_with_note(): void
+    {
+        Notification::fake();
+
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 2,
+            'status' => BorrowingStatus::Rejected,
+            'rejection_note' => 'Stok dialokasikan untuk kegiatan training direksi.',
+        ]);
+
+        $job = new SendBorrowingNotification($borrowing, 'rejected');
+        $job->handle();
+
+        Notification::assertSentTo($this->staff, BorrowingRejectedNotification::class, function ($notification) use ($borrowing) {
+            $mailData = $notification->toMail($this->staff);
+            $arrayData = $notification->toArray($this->staff);
+
+            $this->assertStringContainsString($borrowing->code, $mailData->subject);
+            $this->assertStringContainsString('Alasan Penolakan', implode(' ', $mailData->introLines));
+            $this->assertStringContainsString('Stok dialokasikan untuk kegiatan training direksi.', implode(' ', $mailData->introLines));
+
+            $this->assertEquals('borrowing_rejected', $arrayData['type']);
+            $this->assertEquals($borrowing->id, $arrayData['borrowing_id']);
+            $this->assertEquals('Stok dialokasikan untuk kegiatan training direksi.', $arrayData['rejection_note']);
+
+            return true;
+        });
+    }
+
+    public function test_whitebox_job_handles_rejected_notification_without_note(): void
+    {
+        Notification::fake();
+
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'status' => BorrowingStatus::Rejected,
+            'rejection_note' => null,
+        ]);
+
+        $job = new SendBorrowingNotification($borrowing, 'rejected');
+        $job->handle();
+
+        Notification::assertSentTo($this->staff, BorrowingRejectedNotification::class, function ($notification) {
+            $arrayData = $notification->toArray($this->staff);
+            $this->assertEquals('borrowing_rejected', $arrayData['type']);
+            $this->assertNull($arrayData['rejection_note']);
+
+            return true;
+        });
+    }
+
+    /* =========================================================================
+     * ⚫ BLACK-BOX TESTING (API Endpoints Dispatching Queue Jobs)
+     * ========================================================================= */
+
+    public function test_blackbox_approve_endpoint_dispatches_notification_job(): void
+    {
+        Queue::fake();
+        Sanctum::actingAs($this->admin);
+
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 2,
+            'status' => BorrowingStatus::Pending,
+        ]);
+
+        $response = $this->postJson("/api/borrowings/{$borrowing->id}/approve");
+
+        $response->assertStatus(200);
+
+        Queue::assertPushed(SendBorrowingNotification::class, function ($job) use ($borrowing) {
+            return $job->notificationType === 'approved'
+                && $job->borrowing->id === $borrowing->id;
+        });
+    }
+
+    public function test_blackbox_reject_endpoint_dispatches_notification_job(): void
+    {
+        Queue::fake();
+        Sanctum::actingAs($this->admin);
+
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'status' => BorrowingStatus::Pending,
+        ]);
+
+        $response = $this->postJson("/api/borrowings/{$borrowing->id}/reject", [
+            'rejection_note' => 'Permintaan melebihi batas kuota peminjaman divisi.',
+        ]);
+
+        $response->assertStatus(200);
+
+        Queue::assertPushed(SendBorrowingNotification::class, function ($job) use ($borrowing) {
+            return $job->notificationType === 'rejected'
+                && $job->borrowing->id === $borrowing->id
+                && $job->borrowing->rejection_note === 'Permintaan melebihi batas kuota peminjaman divisi.';
+        });
+    }
+
+    /* =========================================================================
+     * 🔘 GREY-BOX TESTING (Database Notifications Table Persistence)
+     * ========================================================================= */
+
+    public function test_greybox_rejected_notification_persists_in_database_table(): void
+    {
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 1,
+            'status' => BorrowingStatus::Rejected,
+            'rejection_note' => 'Database persistence verification note',
+        ]);
+
+        // Send notification directly via model
+        $this->staff->notify(new BorrowingRejectedNotification($borrowing));
+
+        $this->assertDatabaseHas('notifications', [
+            'notifiable_type' => get_class($this->staff),
+            'notifiable_id' => $this->staff->id,
+            'type' => BorrowingRejectedNotification::class,
+        ]);
+
+        $dbNotification = $this->staff->notifications()->first();
+        $this->assertNotNull($dbNotification);
+        $this->assertEquals('borrowing_rejected', $dbNotification->data['type']);
+        $this->assertEquals('Database persistence verification note', $dbNotification->data['rejection_note']);
+    }
+
+    public function test_greybox_approved_notification_persists_in_database_table(): void
+    {
+        $borrowing = Borrowing::factory()->create([
+            'user_id' => $this->staff->id,
+            'item_id' => $this->item->id,
+            'quantity' => 3,
+            'status' => BorrowingStatus::Dipinjam,
+            'approved_by' => $this->admin->id,
+        ]);
+
+        $this->staff->notify(new BorrowingApprovedNotification($borrowing));
+
+        $this->assertDatabaseHas('notifications', [
+            'notifiable_type' => get_class($this->staff),
+            'notifiable_id' => $this->staff->id,
+            'type' => BorrowingApprovedNotification::class,
+        ]);
+
+        $dbNotification = $this->staff->notifications()->first();
+        $this->assertNotNull($dbNotification);
+        $this->assertEquals('borrowing_approved', $dbNotification->data['type']);
+        $this->assertEquals($borrowing->id, $dbNotification->data['borrowing_id']);
+    }
+}


### PR DESCRIPTION
## Summary of Changes

Closes #53

### Problem
Previously, while `BorrowingApprovedNotification` existed, `SendBorrowingNotification::handle()` had a stub for rejection notifications (`case 'rejected': // Implement if rejection notification exists`), and `BorrowingService::rejectBorrowing()` did not dispatch any notification. Users were not notified by email or database notification when their borrowing requests were rejected (F5 in Roadmap).

### Solution
1. **BorrowingRejectedNotification Class**:
   - Implemented `BorrowingRejectedNotification` supporting `mail` and `database` channels, incorporating borrowing code, item name, quantity, borrow date, and optional `rejection_note`.
2. **SendBorrowingNotification Queue Job**:
   - Implemented `case 'rejected':` to send `BorrowingRejectedNotification` to `$user`.
3. **BorrowingService Rejection Dispatch**:
   - Added `SendBorrowingNotification::dispatch($rejectedBorrowing, 'rejected')` to `BorrowingService::rejectBorrowing()`.
4. **Tri-Layer Test Suite**:
   - Created `BorrowingNotificationTest.php` covering White-Box (mail rendering & array structures for approved/rejected), Black-Box (endpoint queue dispatching), and Grey-Box (database notifications table persistence).
5. **Roadmap**:
   - Updated `docs/ROADMAP_TASKS.md` marking F5 and Phase 5 as 100% complete.

### Testing Checklist
- [x] Tri-Layer suite `BorrowingNotificationTest`: 7 tests, 26 assertions passed.
- [x] Full borrowing test suite: 109 tests, 516 assertions passed (`OK (109 tests, 516 assertions)`).
- [x] Vite asset build completed cleanly (`npm run build`).
