### PR TITLE
perf(borrowing): remove overdue mutation from index and delegate to scheduled command (F11)

### DIFF
--- a/app/Http/Controllers/Api/BorrowingController.php
+++ b/app/Http/Controllers/Api/BorrowingController.php
@@ -96,9 +96,6 @@ class BorrowingController extends Controller
             $query->latest();
         }
 
-        // Batch update overdue status atomically via service
-        $this->borrowingService->checkOverdueBorrowings(dispatchNotifications: false);
-
         $borrowings = $query->paginate($request->per_page ?? 15);
         $borrowings->through(fn ($borrowing) => new BorrowingResource($borrowing));
 

--- a/tests/Feature/BorrowingIndexNPlusOneTest.php
+++ b/tests/Feature/BorrowingIndexNPlusOneTest.php
@@ -155,17 +155,17 @@ class BorrowingIndexNPlusOneTest extends TestCase
         DB::disableQueryLog();
 
         // Check the queries executed:
-        // Before the fix, there was 1 query to get all items + 15 individual UPDATE queries (N+1) + paginate queries
-        // With batch update, there should be exactly ONE update query for all overdue records, NOT 15 updates!
+        // In F11, mutation was removed from index() and delegated to scheduled command.
+        // Index GET request is pure read-only with ZERO UPDATE queries!
         $updateQueries = array_filter($queries, function ($q) {
             return stripos($q['query'], 'update') !== false && stripos($q['query'], 'borrowings') !== false;
         });
 
-        // Assert exactly 1 batch update query was executed (O(1) instead of O(N))
-        $this->assertCount(1, $updateQueries, 'Expected exactly 1 atomic batch UPDATE query, found ' . count($updateQueries));
+        // Assert 0 update queries during index read
+        $this->assertCount(0, $updateQueries, 'Expected 0 UPDATE queries during index read, found ' . count($updateQueries));
 
-        // Ensure total queries is small and constant (batch update + count + select limit + eager loads)
-        $this->assertLessThanOrEqual(6, count($queries), 'Total queries exceeded threshold, possible query leak.');
+        // Ensure total queries is small and constant (count + select limit + eager loads)
+        $this->assertLessThanOrEqual(5, count($queries), 'Total queries exceeded threshold, possible query leak.');
     }
 
     public function test_whitebox_artisan_command_updates_overdue_borrowings(): void
@@ -236,11 +236,23 @@ class BorrowingIndexNPlusOneTest extends TestCase
             'return_date' => Carbon::today()->subDays(2)->toDateString(),
         ]);
 
-        // Trigger index action
+        // 1. Trigger index action - pure read (assert is_overdue flag is true in resource, but DB record not mutated by GET)
         $response = $this->getJson('/api/borrowings');
         $response->assertStatus(200);
 
-        // Direct database assertions
+        $eligibleData = collect($response->json('data'))->firstWhere('id', $eligible->id);
+        $this->assertTrue($eligibleData['is_overdue']);
+
+        // Before scheduled command runs, DB status remains 'dipinjam' (CQS separation)
+        $this->assertDatabaseHas('borrowings', [
+            'id' => $eligible->id,
+            'status' => 'dipinjam',
+        ]);
+
+        // 2. Execute the scheduled Artisan command
+        $this->artisan('borrowings:check-overdue')->assertSuccessful();
+
+        // Direct database assertions after scheduled command execution
         $this->assertDatabaseHas('borrowings', [
             'id' => $eligible->id,
             'status' => 'terlambat',


### PR DESCRIPTION
## Summary

Removes database status mutation from `BorrowingController@index` and delegates overdue checking exclusively to the scheduled Artisan command according to **F11** (Sprint 4 / Phase 7 Performance & UX).

Closes #59

### Key Implementations
1. **Pure Read-Only `index` Endpoint (CQS Compliance)**:
   - In [`app/Http/Controllers/Api/BorrowingController.php`](file:///c:/Users/user/Documents/MyProject/Sistem-Inventaris-Peminjaman-Barang/app/Http/Controllers/Api/BorrowingController.php):
     - Removed `$this->borrowingService->checkOverdueBorrowings(dispatchNotifications: false);` from `index()`.
     - Ensures `GET /api/borrowings` performs **zero UPDATE queries** and produces zero write locks on the `borrowings` table under concurrent read load.
     - Kept dynamic query filtering (`?overdue=true`) to accurately retrieve both records with status `'terlambat'` and active `'dipinjam'` records past their due dates.
     - `BorrowingResource` continues to dynamically calculate `is_overdue` and `days_overdue` for frontend presentation.

2. **Scheduled Command Verification**:
   - Verified that `php artisan borrowings:check-overdue` (and alias `borrowings:update-overdue`) in [`app/Console/Commands/CheckOverdueBorrowings.php`](file:///c:/Users/user/Documents/MyProject/Sistem-Inventaris-Peminjaman-Barang/app/Console/Commands/CheckOverdueBorrowings.php) is scheduled in [`routes/console.php`](file:///c:/Users/user/Documents/MyProject/Sistem-Inventaris-Peminjaman-Barang/routes/console.php) to run daily at 09:00.

3. **Tri-Layer Test Suite Refinement**:
   - In [`tests/Feature/BorrowingIndexNPlusOneTest.php`](file:///c:/Users/user/Documents/MyProject/Sistem-Inventaris-Peminjaman-Barang/tests/Feature/BorrowingIndexNPlusOneTest.php):
     - **White-Box**: Confirmed `GET /api/borrowings` executes 0 UPDATE queries during list retrieval, keeping total queries strictly bounded.
     - **Black-Box**: Confirmed `GET /api/borrowings?overdue=true` filtering matches overdue borrowings and formats resources accurately.
     - **Grey-Box**: Confirmed `GET /api/borrowings` does not mutate database records (status remains `dipinjam`), and confirmed running the scheduled command `borrowings:check-overdue` transitions only eligible past-due records to `terlambat`.

---

## Testing & Verification
- **PHPUnit Borrowing Test Suite**: 109 tests passed (519 assertions)
  - `php vendor/phpunit/phpunit/phpunit tests/Feature/BorrowingIndexNPlusOneTest.php tests/Feature/BorrowingResourceIntegrationTest.php tests/Feature/BorrowingNotificationTest.php tests/Feature/BorrowingRejectWithNoteTest.php tests/Feature/BorrowingStorePendingTest.php tests/Feature/BorrowingServiceIntegrationTest.php tests/Feature/BorrowingStockRaceConditionTest.php tests/Feature/BorrowingPolicyTest.php tests/Feature/BorrowingStatusEnumTest.php tests/Unit/BorrowingServiceTest.php`
- **Frontend Build**: `npm run build --prefix frontend` successfully compiled with zero errors.
