### PR TITLE
feat(frontend): implement infinite scroll mode with dual pagination toggle (F13)

### DIFF
--- a/frontend/src/hooks/useInfiniteScroll.js
+++ b/frontend/src/hooks/useInfiniteScroll.js
@@ -1,0 +1,57 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Custom hook for infinite scrolling using IntersectionObserver.
+ * 
+ * @param {Object} options
+ * @param {Function} options.onLoadMore - Function to invoke when sentinel enters viewport
+ * @param {boolean} [options.hasMore=false] - Whether more items/pages are available to load
+ * @param {boolean} [options.loading=false] - Loading state flag to prevent concurrent requests
+ * @param {string} [options.rootMargin='200px'] - Pre-load margin before reaching the bottom
+ * @param {number|number[]} [options.threshold=0] - Visibility threshold (0 to 1)
+ * @returns {{ sentinelRef: React.RefObject<HTMLElement> }} Ref to attach to the sentinel DOM node
+ */
+export function useInfiniteScroll({
+  onLoadMore,
+  hasMore = false,
+  loading = false,
+  rootMargin = '200px',
+  threshold = 0,
+}) {
+  const sentinelRef = useRef(null);
+  const onLoadMoreRef = useRef(onLoadMore);
+
+  // Keep callback reference updated without retriggering effect
+  useEffect(() => {
+    onLoadMoreRef.current = onLoadMore;
+  }, [onLoadMore]);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    if (typeof IntersectionObserver === 'undefined') return;
+
+    // Do not attach observer if no more items or currently loading
+    if (!hasMore || loading) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const [entry] = entries;
+        if (entry && entry.isIntersecting) {
+          onLoadMoreRef.current?.();
+        }
+      },
+      { rootMargin, threshold }
+    );
+
+    observer.observe(sentinel);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [hasMore, loading, rootMargin, threshold]);
+
+  return { sentinelRef };
+}
+
+export default useInfiniteScroll;

--- a/frontend/src/pages/BorrowingList.jsx
+++ b/frontend/src/pages/BorrowingList.jsx
@@ -1,50 +1,125 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useDebounce } from '../hooks/useDebounce';
+import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import { authService } from '../services/authService';
 import { borrowingService } from '../services/borrowingService';
 
 function BorrowingList() {
   const [borrowings, setBorrowings] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [search, setSearch] = useState('');
+  const debouncedSearch = useDebounce(search, 400);
   const [statusFilter, setStatusFilter] = useState('');
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
+  const [displayMode, setDisplayMode] = useState('pagination'); // 'pagination' | 'infinite'
   const isAdmin = authService.isAdmin();
 
-  useEffect(() => {
-    loadBorrowings();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentPage, search, statusFilter, startDate, endDate]);
+  // Track filter changes to reset page to 1
+  const prevFiltersRef = useRef({
+    search: debouncedSearch,
+    status: statusFilter,
+    startDate,
+    endDate,
+  });
 
-  const loadBorrowings = async () => {
-    try {
-      setLoading(true);
-      const params = {
-        page: currentPage,
-        search,
+  const loadBorrowings = useCallback(
+    async (pageToLoad, isAppend = false) => {
+      try {
+        if (isAppend) {
+          setLoadingMore(true);
+        } else {
+          setLoading(true);
+        }
+
+        const params = {
+          page: pageToLoad,
+          search: debouncedSearch,
+          status: statusFilter,
+          start_date: startDate,
+          end_date: endDate,
+        };
+
+        const response = await borrowingService.getAll(params);
+        const data = response.data?.data || response.data || [];
+        const lastPage = response.data?.last_page || response.last_page || 1;
+
+        setTotalPages(lastPage);
+
+        if (isAppend) {
+          setBorrowings((prev) => [...prev, ...data]);
+        } else {
+          setBorrowings(data);
+        }
+      } catch (error) {
+        console.error('Failed to load borrowings:', error);
+        if (!isAppend) {
+          alert('Gagal memuat data peminjaman');
+        }
+      } finally {
+        setLoading(false);
+        setLoadingMore(false);
+      }
+    },
+    [debouncedSearch, statusFilter, startDate, endDate]
+  );
+
+  useEffect(() => {
+    const prev = prevFiltersRef.current;
+    const filtersChanged =
+      prev.search !== debouncedSearch ||
+      prev.status !== statusFilter ||
+      prev.startDate !== startDate ||
+      prev.endDate !== endDate;
+
+    if (filtersChanged) {
+      prevFiltersRef.current = {
+        search: debouncedSearch,
         status: statusFilter,
-        start_date: startDate,
-        end_date: endDate,
+        startDate,
+        endDate,
       };
-      const response = await borrowingService.getAll(params);
-      setBorrowings(response.data.data || response.data);
-      setTotalPages(response.data.last_page || 1);
-    } catch {
-      alert('Gagal memuat data peminjaman');
-    } finally {
-      setLoading(false);
+
+      if (currentPage !== 1) {
+        setCurrentPage(1);
+        return;
+      }
     }
+
+    const isAppend = displayMode === 'infinite' && currentPage > 1 && !filtersChanged;
+    loadBorrowings(currentPage, isAppend);
+  }, [currentPage, debouncedSearch, statusFilter, startDate, endDate, displayMode, loadBorrowings]);
+
+  const handleModeChange = (mode) => {
+    if (mode === displayMode) return;
+    setDisplayMode(mode);
+    setCurrentPage(1);
   };
+
+  const handleLoadMore = useCallback(() => {
+    if (displayMode === 'infinite' && !loading && !loadingMore && currentPage < totalPages) {
+      setCurrentPage((prev) => prev + 1);
+    }
+  }, [displayMode, loading, loadingMore, currentPage, totalPages]);
+
+  const { sentinelRef } = useInfiniteScroll({
+    onLoadMore: handleLoadMore,
+    hasMore: displayMode === 'infinite' && currentPage < totalPages,
+    loading: loading || loadingMore,
+    rootMargin: '250px',
+  });
 
   const handleApprove = async (id) => {
     if (!confirm('Approve peminjaman ini?')) return;
 
     try {
       await borrowingService.approve(id);
-      loadBorrowings();
+      loadBorrowings(1, false);
+      setCurrentPage(1);
     } catch (error) {
       alert('Gagal approve peminjaman: ' + (error.response?.data?.message || 'Terjadi kesalahan'));
     }
@@ -73,9 +148,57 @@ function BorrowingList() {
   return (
     <div>
       {/* Header */}
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">Manajemen Peminjaman</h1>
-        <p className="text-gray-600 mt-1">Kelola peminjaman barang inventaris</p>
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Manajemen Peminjaman</h1>
+          <p className="text-gray-600 mt-1">Kelola peminjaman barang inventaris</p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          {/* Dual-Mode Toggle */}
+          <div className="inline-flex bg-gray-100 p-1 rounded-lg border border-gray-200 text-xs font-medium">
+            <button
+              type="button"
+              onClick={() => handleModeChange('pagination')}
+              className={`px-3 py-1.5 rounded-md transition-all flex items-center space-x-1.5 ${
+                displayMode === 'pagination'
+                  ? 'bg-white text-gray-900 shadow-sm font-semibold'
+                  : 'text-gray-600 hover:text-gray-900'
+              }`}
+              title="Mode Halaman Tradisional"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              <span>Halaman</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => handleModeChange('infinite')}
+              className={`px-3 py-1.5 rounded-md transition-all flex items-center space-x-1.5 ${
+                displayMode === 'infinite'
+                  ? 'bg-white text-blue-600 shadow-sm font-semibold'
+                  : 'text-gray-600 hover:text-gray-900'
+              }`}
+              title="Mode Scroll Otomatis (Infinite Scroll)"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+              </svg>
+              <span>Scroll Otomatis</span>
+            </button>
+          </div>
+
+          <Link
+            to="/borrowings/create"
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center space-x-2 text-sm font-medium shadow-sm"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            <span>Pinjam Barang</span>
+          </Link>
+        </div>
       </div>
 
       {/* Filters */}
@@ -131,18 +254,6 @@ function BorrowingList() {
             />
           </div>
         </div>
-
-        <div className="mt-4 flex justify-end">
-          <Link
-            to="/borrowings/create"
-            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center space-x-2"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-            </svg>
-            <span>Pinjam Barang</span>
-          </Link>
-        </div>
       </div>
 
       {/* Table */}
@@ -160,118 +271,142 @@ function BorrowingList() {
             <p className="mt-4 text-gray-600">Tidak ada data peminjaman</p>
           </div>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
-                <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Kode</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Peminjam</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Barang</th>
-                  <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Qty</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tgl Pinjam</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Jatuh Tempo</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tgl Kembali</th>
-                  <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                  <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Aksi</th>
-                </tr>
-              </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
-                {borrowings.map((borrowing) => (
-                  <tr key={borrowing.id} className="hover:bg-gray-50">
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm font-medium text-gray-900">{borrowing.code}</div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm text-gray-900">{borrowing.user?.name}</div>
-                      <div className="text-sm text-gray-500">{borrowing.user?.email}</div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm text-gray-900">{borrowing.item?.name}</div>
-                      <div className="text-sm text-gray-500">{borrowing.item?.code}</div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-center">
-                      <span className="text-sm font-medium text-gray-900">{borrowing.quantity}</span>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
-                      {new Date(borrowing.borrow_date).toLocaleDateString('id-ID')}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
-                      {new Date(borrowing.due_date).toLocaleDateString('id-ID')}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
-                      {borrowing.return_date ? new Date(borrowing.return_date).toLocaleDateString('id-ID') : '-'}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-center">
-                      <span className={`inline-block px-3 py-1 text-xs font-semibold rounded-full ${getStatusBadge(borrowing)}`}>
-                        {getStatusText(borrowing)}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-center text-sm font-medium">
-                      <Link
-                        to={`/borrowings/${borrowing.id}`}
-                        className="text-blue-600 hover:text-blue-900 mr-3"
-                        title="Detail"
-                      >
-                        <svg className="w-5 h-5 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                        </svg>
-                      </Link>
-                      {borrowing.status === 'approved' && (
+          <>
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Kode</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Peminjam</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Barang</th>
+                    <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Qty</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tgl Pinjam</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Jatuh Tempo</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tgl Kembali</th>
+                    <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                    <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Aksi</th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
+                  {borrowings.map((borrowing) => (
+                    <tr key={borrowing.id} className="hover:bg-gray-50">
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm font-medium text-gray-900">{borrowing.code}</div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm text-gray-900">{borrowing.user?.name}</div>
+                        <div className="text-sm text-gray-500">{borrowing.user?.email}</div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm text-gray-900">{borrowing.item?.name}</div>
+                        <div className="text-sm text-gray-500">{borrowing.item?.code}</div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-center">
+                        <span className="text-sm font-medium text-gray-900">{borrowing.quantity}</span>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                        {new Date(borrowing.borrow_date).toLocaleDateString('id-ID')}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                        {new Date(borrowing.due_date).toLocaleDateString('id-ID')}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                        {borrowing.return_date ? new Date(borrowing.return_date).toLocaleDateString('id-ID') : '-'}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-center">
+                        <span className={`inline-block px-3 py-1 text-xs font-semibold rounded-full ${getStatusBadge(borrowing)}`}>
+                          {getStatusText(borrowing)}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-center text-sm font-medium">
                         <Link
-                          to={`/borrowings/${borrowing.id}/return`}
-                          className="text-green-600 hover:text-green-900 mr-3"
-                          title="Kembalikan"
+                          to={`/borrowings/${borrowing.id}`}
+                          className="text-blue-600 hover:text-blue-900 mr-3"
+                          title="Detail"
                         >
                           <svg className="w-5 h-5 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
                           </svg>
                         </Link>
-                      )}
-                      {isAdmin && borrowing.status === 'pending' && (
-                        <button
-                          onClick={() => handleApprove(borrowing.id)}
-                          className="text-purple-600 hover:text-purple-900"
-                          title="Approve"
-                        >
-                          <svg className="w-5 h-5 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                          </svg>
-                        </button>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-
-        {/* Pagination */}
-        {totalPages > 1 && (
-          <div className="px-6 py-4 border-t border-gray-200">
-            <div className="flex items-center justify-between">
-              <div className="text-sm text-gray-600">
-                Halaman {currentPage} dari {totalPages}
-              </div>
-              <div className="flex space-x-2">
-                <button
-                  onClick={() => setCurrentPage(currentPage - 1)}
-                  disabled={currentPage === 1}
-                  className="px-3 py-1 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  Previous
-                </button>
-                <button
-                  onClick={() => setCurrentPage(currentPage + 1)}
-                  disabled={currentPage === totalPages}
-                  className="px-3 py-1 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  Next
-                </button>
-              </div>
+                        {borrowing.status === 'approved' && (
+                          <Link
+                            to={`/borrowings/${borrowing.id}/return`}
+                            className="text-green-600 hover:text-green-900 mr-3"
+                            title="Kembalikan"
+                          >
+                            <svg className="w-5 h-5 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
+                            </svg>
+                          </Link>
+                        )}
+                        {isAdmin && borrowing.status === 'pending' && (
+                          <button
+                            onClick={() => handleApprove(borrowing.id)}
+                            className="text-purple-600 hover:text-purple-900"
+                            title="Approve"
+                          >
+                            <svg className="w-5 h-5 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                            </svg>
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
-          </div>
+
+            {/* Mode Infinite Scroll: Sentinel / Footer Notice */}
+            {displayMode === 'infinite' && (
+              <div className="bg-white px-6 py-4 border-t border-gray-200">
+                {currentPage < totalPages ? (
+                  <div ref={sentinelRef} className="flex flex-col items-center justify-center py-2">
+                    {loadingMore ? (
+                      <div className="flex items-center space-x-2 text-blue-600 text-sm font-medium">
+                        <div className="inline-block animate-spin rounded-full h-5 w-5 border-b-2 border-blue-600"></div>
+                        <span>Memuat lebih banyak peminjaman...</span>
+                      </div>
+                    ) : (
+                      <span className="text-xs text-gray-400">Gulir ke bawah untuk memuat lebih banyak...</span>
+                    )}
+                  </div>
+                ) : (
+                  <p className="text-center text-sm text-gray-500 py-1 font-medium">
+                    Semua peminjaman telah ditampilkan ({borrowings.length} data)
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Mode Pagination: Traditional Numbered Buttons */}
+            {displayMode === 'pagination' && totalPages > 1 && (
+              <div className="px-6 py-4 border-t border-gray-200">
+                <div className="flex items-center justify-between">
+                  <div className="text-sm text-gray-600">
+                    Halaman <span className="font-medium">{currentPage}</span> dari <span className="font-medium">{totalPages}</span>
+                  </div>
+                  <div className="flex space-x-2">
+                    <button
+                      onClick={() => setCurrentPage(currentPage - 1)}
+                      disabled={currentPage === 1}
+                      className="px-3 py-1 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+                    >
+                      Previous
+                    </button>
+                    <button
+                      onClick={() => setCurrentPage(currentPage + 1)}
+                      disabled={currentPage === totalPages}
+                      className="px-3 py-1 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+                    >
+                      Next
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/frontend/src/pages/ItemList.jsx
+++ b/frontend/src/pages/ItemList.jsx
@@ -1,5 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useDebounce } from '../hooks/useDebounce';
+import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import { categoryService } from '../services/categoryService';
 import { itemService } from '../services/itemService';
 
@@ -7,13 +9,23 @@ function ItemList() {
   const [items, setItems] = useState([]);
   const [categories, setCategories] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [search, setSearch] = useState('');
+  const debouncedSearch = useDebounce(search, 400);
   const [categoryFilter, setCategoryFilter] = useState('');
   const [conditionFilter, setConditionFilter] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
+  const [displayMode, setDisplayMode] = useState('pagination'); // 'pagination' | 'infinite'
 
-  // Memoize loadCategories untuk menghindari re-creation
+  // Ref tracking prior filters to reset page to 1 upon changes
+  const prevFiltersRef = useRef({
+    search: debouncedSearch,
+    category: categoryFilter,
+    condition: conditionFilter,
+  });
+
+  // Memoize loadCategories
   const loadCategories = useCallback(async () => {
     try {
       const response = await categoryService.getAll({ all: true });
@@ -23,44 +35,102 @@ function ItemList() {
     }
   }, []);
 
-  // Memoize loadItems untuk menghindari re-creation
-  const loadItems = useCallback(async () => {
-    try {
-      setLoading(true);
-      const params = {
-        page: currentPage,
-        search,
-        category_id: categoryFilter,
-        condition: conditionFilter,
-      };
-      const response = await itemService.getAll(params);
-      setItems(response.data);
-      setTotalPages(response.last_page || 1);
-    } catch (error) {
-      console.error('Failed to load items:', error);
-    } finally {
-      setLoading(false);
-    }
-  }, [currentPage, search, categoryFilter, conditionFilter]);
+  // Memoize loadItems
+  const loadItems = useCallback(
+    async (pageToLoad, isAppend = false) => {
+      try {
+        if (isAppend) {
+          setLoadingMore(true);
+        } else {
+          setLoading(true);
+        }
+
+        const params = {
+          page: pageToLoad,
+          search: debouncedSearch,
+          category_id: categoryFilter,
+          condition: conditionFilter,
+        };
+
+        const response = await itemService.getAll(params);
+        const data = response.data || [];
+        const lastPage = response.last_page || response.meta?.last_page || 1;
+
+        setTotalPages(lastPage);
+
+        if (isAppend) {
+          setItems((prev) => [...prev, ...data]);
+        } else {
+          setItems(data);
+        }
+      } catch (error) {
+        console.error('Failed to load items:', error);
+      } finally {
+        setLoading(false);
+        setLoadingMore(false);
+      }
+    },
+    [debouncedSearch, categoryFilter, conditionFilter]
+  );
 
   useEffect(() => {
     loadCategories();
   }, [loadCategories]);
 
+  // Load items when page, filters, or mode changes
   useEffect(() => {
-    loadItems();
-  }, [loadItems]);
+    const prev = prevFiltersRef.current;
+    const filtersChanged =
+      prev.search !== debouncedSearch ||
+      prev.category !== categoryFilter ||
+      prev.condition !== conditionFilter;
+
+    if (filtersChanged) {
+      prevFiltersRef.current = {
+        search: debouncedSearch,
+        category: categoryFilter,
+        condition: conditionFilter,
+      };
+
+      if (currentPage !== 1) {
+        setCurrentPage(1);
+        return;
+      }
+    }
+
+    const isAppend = displayMode === 'infinite' && currentPage > 1 && !filtersChanged;
+    loadItems(currentPage, isAppend);
+  }, [currentPage, debouncedSearch, categoryFilter, conditionFilter, displayMode, loadItems]);
+
+  const handleModeChange = (mode) => {
+    if (mode === displayMode) return;
+    setDisplayMode(mode);
+    setCurrentPage(1);
+  };
+
+  const handleLoadMore = useCallback(() => {
+    if (displayMode === 'infinite' && !loading && !loadingMore && currentPage < totalPages) {
+      setCurrentPage((prev) => prev + 1);
+    }
+  }, [displayMode, loading, loadingMore, currentPage, totalPages]);
+
+  const { sentinelRef } = useInfiniteScroll({
+    onLoadMore: handleLoadMore,
+    hasMore: displayMode === 'infinite' && currentPage < totalPages,
+    loading: loading || loadingMore,
+    rootMargin: '250px',
+  });
 
   const handleDelete = useCallback(async (id) => {
     if (!window.confirm('Yakin ingin menghapus barang ini?')) return;
 
     try {
       await itemService.delete(id);
-      loadItems();
+      setItems((prev) => prev.filter((item) => item.id !== id));
     } catch (error) {
       alert(error.response?.data?.message || 'Gagal menghapus barang');
     }
-  }, [loadItems]);
+  }, []);
 
   // Memoize condition badge calculator
   const getConditionBadge = useMemo(() => {
@@ -75,20 +145,57 @@ function ItemList() {
   return (
     <div>
       {/* Header */}
-      <div className="flex justify-between items-center mb-6">
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-6">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Manajemen Barang</h1>
           <p className="text-gray-600 mt-1">Kelola data barang inventaris</p>
         </div>
-        <Link
-          to="/items/create"
-          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center space-x-2"
-        >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
-          <span>Tambah Barang</span>
-        </Link>
+
+        <div className="flex flex-wrap items-center gap-3">
+          {/* Dual-Mode Toggle */}
+          <div className="inline-flex bg-gray-100 p-1 rounded-lg border border-gray-200 text-xs font-medium">
+            <button
+              type="button"
+              onClick={() => handleModeChange('pagination')}
+              className={`px-3 py-1.5 rounded-md transition-all flex items-center space-x-1.5 ${
+                displayMode === 'pagination'
+                  ? 'bg-white text-gray-900 shadow-sm font-semibold'
+                  : 'text-gray-600 hover:text-gray-900'
+              }`}
+              title="Mode Halaman Tradisional"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              <span>Halaman</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => handleModeChange('infinite')}
+              className={`px-3 py-1.5 rounded-md transition-all flex items-center space-x-1.5 ${
+                displayMode === 'infinite'
+                  ? 'bg-white text-blue-600 shadow-sm font-semibold'
+                  : 'text-gray-600 hover:text-gray-900'
+              }`}
+              title="Mode Scroll Otomatis (Infinite Scroll)"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+              </svg>
+              <span>Scroll Otomatis</span>
+            </button>
+          </div>
+
+          <Link
+            to="/items/create"
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center space-x-2 text-sm font-medium shadow-sm"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            <span>Tambah Barang</span>
+          </Link>
+        </div>
       </div>
 
       {/* Filters */}
@@ -232,8 +339,30 @@ function ItemList() {
               </tbody>
             </table>
 
-            {/* Pagination */}
-            {totalPages > 1 && (
+            {/* Mode Infinite Scroll: Sentinel / Footer Notice */}
+            {displayMode === 'infinite' && (
+              <div className="bg-white px-6 py-4 border-t border-gray-200">
+                {currentPage < totalPages ? (
+                  <div ref={sentinelRef} className="flex flex-col items-center justify-center py-2">
+                    {loadingMore ? (
+                      <div className="flex items-center space-x-2 text-blue-600 text-sm font-medium">
+                        <div className="inline-block animate-spin rounded-full h-5 w-5 border-b-2 border-blue-600"></div>
+                        <span>Memuat lebih banyak barang...</span>
+                      </div>
+                    ) : (
+                      <span className="text-xs text-gray-400">Gulir ke bawah untuk memuat lebih banyak...</span>
+                    )}
+                  </div>
+                ) : (
+                  <p className="text-center text-sm text-gray-500 py-1 font-medium">
+                    Semua barang telah ditampilkan ({items.length} data)
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Mode Pagination: Traditional Numbered Buttons */}
+            {displayMode === 'pagination' && totalPages > 1 && (
               <div className="bg-white px-4 py-3 flex items-center justify-between border-t border-gray-200 sm:px-6">
                 <div className="flex-1 flex justify-between sm:hidden">
                   <button

--- a/frontend/src/test/hooks/useInfiniteScroll.test.jsx
+++ b/frontend/src/test/hooks/useInfiniteScroll.test.jsx
@@ -1,0 +1,138 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import useInfiniteScroll from '../../hooks/useInfiniteScroll';
+
+// Helper component to test useInfiniteScroll
+function TestInfiniteScrollComponent({
+  onLoadMore,
+  hasMore = true,
+  loading = false,
+  rootMargin = '200px',
+  threshold = 0,
+}) {
+  const { sentinelRef } = useInfiniteScroll({
+    onLoadMore,
+    hasMore,
+    loading,
+    rootMargin,
+    threshold,
+  });
+
+  return (
+    <div>
+      <div data-testid="content">Content List</div>
+      <div data-testid="sentinel" ref={sentinelRef}>
+        Loading more...
+      </div>
+    </div>
+  );
+}
+
+describe('useInfiniteScroll hook', () => {
+  let observerInstances = [];
+  let originalIntersectionObserver;
+
+  beforeEach(() => {
+    observerInstances = [];
+    originalIntersectionObserver = window.IntersectionObserver;
+
+    // Mock IntersectionObserver
+    window.IntersectionObserver = vi.fn(function (callback, options) {
+      this.callback = callback;
+      this.options = options;
+      this.observedElements = [];
+      this.observe = vi.fn((element) => {
+        this.observedElements.push(element);
+      });
+      this.unobserve = vi.fn((element) => {
+        this.observedElements = this.observedElements.filter((el) => el !== element);
+      });
+      this.disconnect = vi.fn(() => {
+        this.observedElements = [];
+      });
+
+      // Helper to trigger intersection in tests
+      this.triggerIntersect = (isIntersecting = true) => {
+        this.callback([{ isIntersecting, target: this.observedElements[0] }]);
+      };
+
+      observerInstances.push(this);
+    });
+  });
+
+  afterEach(() => {
+    window.IntersectionObserver = originalIntersectionObserver;
+    vi.clearAllMocks();
+  });
+
+  it('observes the sentinel element when hasMore is true and not loading', () => {
+    const onLoadMore = vi.fn();
+    render(<TestInfiniteScrollComponent onLoadMore={onLoadMore} hasMore={true} loading={false} />);
+
+    expect(window.IntersectionObserver).toHaveBeenCalledTimes(1);
+    expect(observerInstances[0].observe).toHaveBeenCalledWith(screen.getByTestId('sentinel'));
+  });
+
+  it('triggers onLoadMore when sentinel intersects the viewport', () => {
+    const onLoadMore = vi.fn();
+    render(<TestInfiniteScrollComponent onLoadMore={onLoadMore} hasMore={true} loading={false} />);
+
+    expect(onLoadMore).not.toHaveBeenCalled();
+
+    act(() => {
+      observerInstances[0].triggerIntersect(true);
+    });
+
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not trigger onLoadMore when entry is not intersecting', () => {
+    const onLoadMore = vi.fn();
+    render(<TestInfiniteScrollComponent onLoadMore={onLoadMore} hasMore={true} loading={false} />);
+
+    act(() => {
+      observerInstances[0].triggerIntersect(false);
+    });
+
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it('does not observe or trigger onLoadMore when loading is true', () => {
+    const onLoadMore = vi.fn();
+    render(<TestInfiniteScrollComponent onLoadMore={onLoadMore} hasMore={true} loading={true} />);
+
+    expect(observerInstances.length).toBe(0);
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it('does not observe or trigger onLoadMore when hasMore is false', () => {
+    const onLoadMore = vi.fn();
+    render(<TestInfiniteScrollComponent onLoadMore={onLoadMore} hasMore={false} loading={false} />);
+
+    expect(observerInstances.length).toBe(0);
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it('disconnects the observer when component unmounts', () => {
+    const onLoadMore = vi.fn();
+    const { unmount } = render(
+      <TestInfiniteScrollComponent onLoadMore={onLoadMore} hasMore={true} loading={false} />
+    );
+
+    const observer = observerInstances[0];
+    expect(observer.disconnect).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(observer.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles gracefully when IntersectionObserver is not supported', () => {
+    delete window.IntersectionObserver;
+    const onLoadMore = vi.fn();
+
+    expect(() => {
+      render(<TestInfiniteScrollComponent onLoadMore={onLoadMore} hasMore={true} loading={false} />);
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary of Changes
Implements dual-mode pagination and infinite scrolling for `ItemList.jsx` and `BorrowingList.jsx` to optimize UX when handling large sets of data, especially on mobile devices (Closes #63).

### Key Implementations:
1. **Custom Hook `useInfiniteScroll`** (`frontend/src/hooks/useInfiniteScroll.js`):
   - Configurable `rootMargin` and `threshold` based on native `IntersectionObserver`.
   - Guards against race conditions and concurrent requests (`loading` flag and `hasMore`).
   - Clean disconnection and observer management on unmount.
2. **Dual-Mode UI in `ItemList.jsx` & `BorrowingList.jsx`**:
   - Added pill switch toggle between **Halaman (Pagination)** and **Scroll Otomatis (Infinite Scroll)**.
   - Smooth lazy appending of subsequent pages (`setItems(prev => [...prev, ...next])`) with spinning indicators.
   - Reset mechanism ensuring search/filter updates restart fresh from page 1.
   - Debounced search query inputs using `useDebounce`.
3. **Automated Unit Tests**:
   - Added `frontend/src/test/hooks/useInfiniteScroll.test.jsx` covering mock intersections, boundary conditions, unmount cleanup, and fallback handling.

### Verification:
- `npm test --prefix frontend -- --run` (42/42 tests passing)
- `npm run build --prefix frontend` (Rolldown/Vite client build succeeded with 0 errors)
- `php vendor/phpunit/phpunit/phpunit tests/Feature/ItemCachingIntegrationTest.php` (6/6 passing)
