### PR TITLE
feat(ui): implement dark mode support and theme switcher (F15)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import Loading from './components/common/Loading';
 import OfflineBanner from './components/common/OfflineBanner';
 import ErrorBoundary from './components/ErrorBoundary';
+import { ThemeProvider } from './contexts/ThemeContext';
 import { authService } from './services/authService';
 
 // Eager load Layout and Login (critical paths)
@@ -47,54 +48,56 @@ function SuspenseWrapper({ children }) {
 function App() {
   return (
     <ErrorBoundary>
-      <OfflineBanner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/login" element={<Login />} />
-          <Route path="/register" element={<SuspenseWrapper><Register /></SuspenseWrapper>} />
-          <Route path="/forgot-password" element={<SuspenseWrapper><ForgotPassword /></SuspenseWrapper>} />
-          <Route path="/reset-password" element={<SuspenseWrapper><ResetPassword /></SuspenseWrapper>} />
-        
-        {/* Protected Routes with Layout */}
-        <Route
-          path="/"
-          element={
-            <ProtectedRoute>
-              <Layout />
-            </ProtectedRoute>
-          }
-        >
-          <Route index element={<Navigate to="/dashboard" replace />} />
-          <Route path="dashboard" element={<SuspenseWrapper><Dashboard /></SuspenseWrapper>} />
+      <ThemeProvider>
+        <OfflineBanner />
+        <BrowserRouter>
+          <Routes>
+            <Route path="/login" element={<Login />} />
+            <Route path="/register" element={<SuspenseWrapper><Register /></SuspenseWrapper>} />
+            <Route path="/forgot-password" element={<SuspenseWrapper><ForgotPassword /></SuspenseWrapper>} />
+            <Route path="/reset-password" element={<SuspenseWrapper><ResetPassword /></SuspenseWrapper>} />
           
-          {/* Items Routes */}
-          <Route path="items" element={<SuspenseWrapper><ItemList /></SuspenseWrapper>} />
-          <Route path="items/create" element={<SuspenseWrapper><ItemForm /></SuspenseWrapper>} />
-          <Route path="items/:id" element={<SuspenseWrapper><ItemDetail /></SuspenseWrapper>} />
-          <Route path="items/:id/edit" element={<SuspenseWrapper><ItemForm /></SuspenseWrapper>} />
-          
-          {/* Categories Routes */}
-          <Route path="categories" element={<SuspenseWrapper><CategoryList /></SuspenseWrapper>} />
-          
-          {/* Borrowings Routes */}
-          <Route path="borrowings" element={<SuspenseWrapper><BorrowingList /></SuspenseWrapper>} />
-          <Route path="borrowings/create" element={<SuspenseWrapper><BorrowingForm /></SuspenseWrapper>} />
-          <Route path="borrowings/:id" element={<SuspenseWrapper><BorrowingDetail /></SuspenseWrapper>} />
-          <Route path="borrowings/:id/return" element={<SuspenseWrapper><ReturnForm /></SuspenseWrapper>} />
-          
-          {/* Reports Routes */}
-          <Route path="reports" element={<SuspenseWrapper><Reports /></SuspenseWrapper>} />
-          
-          {/* Users Routes (Admin Only) */}
-          <Route path="users" element={<SuspenseWrapper><UserList /></SuspenseWrapper>} />
-          <Route path="users/create" element={<SuspenseWrapper><UserForm /></SuspenseWrapper>} />
-          <Route path="users/:id/edit" element={<SuspenseWrapper><UserForm /></SuspenseWrapper>} />
-          
-          {/* Profile Routes */}
-          <Route path="profile" element={<SuspenseWrapper><Profile /></SuspenseWrapper>} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+            {/* Protected Routes with Layout */}
+            <Route
+              path="/"
+              element={
+                <ProtectedRoute>
+                  <Layout />
+                </ProtectedRoute>
+              }
+            >
+              <Route index element={<Navigate to="/dashboard" replace />} />
+              <Route path="dashboard" element={<SuspenseWrapper><Dashboard /></SuspenseWrapper>} />
+              
+              {/* Items Routes */}
+              <Route path="items" element={<SuspenseWrapper><ItemList /></SuspenseWrapper>} />
+              <Route path="items/create" element={<SuspenseWrapper><ItemForm /></SuspenseWrapper>} />
+              <Route path="items/:id" element={<SuspenseWrapper><ItemDetail /></SuspenseWrapper>} />
+              <Route path="items/:id/edit" element={<SuspenseWrapper><ItemForm /></SuspenseWrapper>} />
+              
+              {/* Categories Routes */}
+              <Route path="categories" element={<SuspenseWrapper><CategoryList /></SuspenseWrapper>} />
+              
+              {/* Borrowings Routes */}
+              <Route path="borrowings" element={<SuspenseWrapper><BorrowingList /></SuspenseWrapper>} />
+              <Route path="borrowings/create" element={<SuspenseWrapper><BorrowingForm /></SuspenseWrapper>} />
+              <Route path="borrowings/:id" element={<SuspenseWrapper><BorrowingDetail /></SuspenseWrapper>} />
+              <Route path="borrowings/:id/return" element={<SuspenseWrapper><ReturnForm /></SuspenseWrapper>} />
+              
+              {/* Reports Routes */}
+              <Route path="reports" element={<SuspenseWrapper><Reports /></SuspenseWrapper>} />
+              
+              {/* Users Routes (Admin Only) */}
+              <Route path="users" element={<SuspenseWrapper><UserList /></SuspenseWrapper>} />
+              <Route path="users/create" element={<SuspenseWrapper><UserForm /></SuspenseWrapper>} />
+              <Route path="users/:id/edit" element={<SuspenseWrapper><UserForm /></SuspenseWrapper>} />
+              
+              {/* Profile Routes */}
+              <Route path="profile" element={<SuspenseWrapper><Profile /></SuspenseWrapper>} />
+            </Route>
+          </Routes>
+        </BrowserRouter>
+      </ThemeProvider>
     </ErrorBoundary>
   );
 }

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { authService } from '../services/authService';
+import ThemeToggle from './common/ThemeToggle';
 
 function Header() {
   const navigate = useNavigate();
@@ -19,20 +20,23 @@ function Header() {
   };
 
   return (
-    <header className="bg-white shadow-sm border-b border-gray-200">
+    <header className="bg-white dark:bg-gray-900 shadow-xs border-b border-gray-200 dark:border-gray-800 transition-colors">
       <div className="px-6 py-4">
         <div className="flex items-center justify-between">
           {/* Breadcrumb / Page Title */}
           <div>
-            <h2 className="text-2xl font-semibold text-gray-800">
+            <h2 className="text-2xl font-semibold text-gray-800 dark:text-gray-100">
               {/* This will be replaced by page-specific title */}
             </h2>
           </div>
 
-          {/* Right side - User menu */}
+          {/* Right side - User menu & Theme switcher */}
           <div className="flex items-center space-x-4">
+            {/* Theme Toggle */}
+            <ThemeToggle />
+
             {/* Notifications */}
-            <button className="p-2 text-gray-400 hover:text-gray-600 relative">
+            <button className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 relative transition-colors">
               <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
               </svg>
@@ -42,15 +46,15 @@ function Header() {
 
             {/* User dropdown */}
             <div className="relative group">
-              <button className="flex items-center space-x-3 px-3 py-2 rounded-lg hover:bg-gray-100">
+              <button className="flex items-center space-x-3 px-3 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
                 <div className="w-8 h-8 rounded-full bg-blue-600 flex items-center justify-center">
                   <span className="text-sm font-semibold text-white">
                     {user?.name?.charAt(0)}
                   </span>
                 </div>
                 <div className="text-left">
-                  <p className="text-sm font-medium text-gray-700">{user?.name}</p>
-                  <p className="text-xs text-gray-500 capitalize">{user?.role}</p>
+                  <p className="text-sm font-medium text-gray-700 dark:text-gray-200">{user?.name}</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 capitalize">{user?.role}</p>
                 </div>
                 <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
@@ -58,11 +62,11 @@ function Header() {
               </button>
 
               {/* Dropdown menu */}
-              <div className="absolute right-0 mt-2 w-48 bg-white rounded-lg shadow-lg border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50">
+              <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50">
                 <div className="py-1">
                   <a
                     href="#"
-                    className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                    className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                     onClick={(e) => {
                       e.preventDefault();
                       navigate('/profile');
@@ -77,7 +81,7 @@ function Header() {
                   </a>
                   <a
                     href="#"
-                    className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                    className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                     onClick={(e) => {
                       e.preventDefault();
                       navigate('/settings');
@@ -91,10 +95,10 @@ function Header() {
                       <span>Pengaturan</span>
                     </div>
                   </a>
-                  <hr className="my-1 border-gray-200" />
+                  <hr className="my-1 border-gray-200 dark:border-gray-700" />
                   <button
                     onClick={handleLogout}
-                    className="block w-full text-left px-4 py-2 text-sm text-red-600 hover:bg-red-50"
+                    className="block w-full text-left px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/30 transition-colors"
                   >
                     <div className="flex items-center space-x-2">
                       <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -4,7 +4,7 @@ import Sidebar from './Sidebar';
 
 function Layout() {
   return (
-    <div className="flex h-screen bg-gray-100">
+    <div className="flex h-screen bg-gray-100 dark:bg-gray-950 transition-colors">
       {/* Sidebar */}
       <Sidebar />
 
@@ -14,7 +14,7 @@ function Layout() {
         <Header />
 
         {/* Page Content */}
-        <main className="flex-1 overflow-x-hidden overflow-y-auto bg-gray-100">
+        <main className="flex-1 overflow-x-hidden overflow-y-auto bg-gray-100 dark:bg-gray-950 text-gray-900 dark:text-gray-100 transition-colors">
           <div className="container mx-auto px-6 py-8">
             <Outlet />
           </div>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -66,17 +66,17 @@ function Sidebar() {
   }
 
   return (
-    <div className="w-64 bg-gray-800 text-white min-h-screen flex flex-col">
+    <div className="w-64 bg-gray-800 dark:bg-gray-900 text-white min-h-screen flex flex-col border-r border-gray-700 dark:border-gray-800 transition-colors">
       {/* Logo */}
-      <div className="p-4 border-b border-gray-700">
+      <div className="p-4 border-b border-gray-700 dark:border-gray-800">
         <h1 className="text-xl font-bold">Sistem Inventaris</h1>
         <p className="text-xs text-gray-400 mt-1">Peminjaman Barang</p>
       </div>
 
       {/* User Info */}
-      <div className="p-4 border-b border-gray-700">
+      <div className="p-4 border-b border-gray-700 dark:border-gray-800">
         <div className="flex items-center space-x-3">
-          <div className="w-10 h-10 rounded-full bg-gray-600 flex items-center justify-center">
+          <div className="w-10 h-10 rounded-full bg-gray-600 dark:bg-gray-700 flex items-center justify-center">
             <span className="text-lg font-semibold">{user?.name?.charAt(0)}</span>
           </div>
           <div className="flex-1 min-w-0">
@@ -96,7 +96,7 @@ function Sidebar() {
               `flex items-center space-x-3 px-4 py-3 rounded-lg transition-colors ${
                 isActive
                   ? 'bg-blue-600 text-white'
-                  : 'text-gray-300 hover:bg-gray-700 hover:text-white'
+                  : 'text-gray-300 hover:bg-gray-700 dark:hover:bg-gray-800 hover:text-white'
               }`
             }
           >
@@ -107,7 +107,7 @@ function Sidebar() {
       </nav>
 
       {/* Footer */}
-      <div className="p-4 border-t border-gray-700">
+      <div className="p-4 border-t border-gray-700 dark:border-gray-800">
         <p className="text-xs text-gray-400 text-center">
           © 2026 Sistem Inventaris
         </p>

--- a/frontend/src/components/common/Card.jsx
+++ b/frontend/src/components/common/Card.jsx
@@ -3,11 +3,11 @@ import { memo } from 'react';
 
 const Card = memo(function Card({ children, title, subtitle, className = '', padding = true, ...props }) {
   return (
-    <div className={`bg-white rounded-lg shadow-md ${className}`} {...props}>
+    <div className={`bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-800 rounded-lg shadow-sm ${className} transition-colors`} {...props}>
       {(title || subtitle) && (
-        <div className={`border-b border-gray-200 ${padding ? 'px-6 py-4' : ''}`}>
-          {title && <h3 className="text-lg font-semibold text-gray-900">{title}</h3>}
-          {subtitle && <p className="text-sm text-gray-600 mt-1">{subtitle}</p>}
+        <div className={`border-b border-gray-200 dark:border-gray-800 ${padding ? 'px-6 py-4' : ''}`}>
+          {title && <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{title}</h3>}
+          {subtitle && <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">{subtitle}</p>}
         </div>
       )}
       <div className={padding ? 'p-6' : ''}>

--- a/frontend/src/components/common/Input.jsx
+++ b/frontend/src/components/common/Input.jsx
@@ -6,14 +6,14 @@ const Input = forwardRef(({
   error, 
   type = 'text', 
   className = '', 
-  required = false,
-  disabled = false,
+  required = false, 
+  disabled = false, 
   ...props 
 }, ref) => {
   return (
     <div className={className}>
       {label && (
-        <label className="block text-sm font-medium text-gray-700 mb-1">
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
           {label}
           {required && <span className="text-red-500 ml-1">*</span>}
         </label>
@@ -24,15 +24,19 @@ const Input = forwardRef(({
         disabled={disabled}
         className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 transition-colors ${
           error 
-            ? 'border-red-300 focus:border-red-500 focus:ring-red-500' 
-            : 'border-gray-300 focus:border-blue-500 focus:ring-blue-500'
-        } ${disabled ? 'bg-gray-100 cursor-not-allowed' : 'bg-white'}`}
+            ? 'border-red-300 dark:border-red-500 focus:border-red-500 focus:ring-red-500' 
+            : 'border-gray-300 dark:border-gray-600 focus:border-blue-500 focus:ring-blue-500'
+        } ${
+          disabled 
+            ? 'bg-gray-100 dark:bg-gray-700/60 text-gray-500 dark:text-gray-400 cursor-not-allowed' 
+            : 'bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500'
+        }`}
         aria-invalid={error ? 'true' : 'false'}
         aria-describedby={error ? `${props.id}-error` : undefined}
         {...props}
       />
       {error && (
-        <p id={`${props.id}-error`} className="mt-1 text-sm text-red-600">
+        <p id={`${props.id}-error`} className="mt-1 text-sm text-red-600 dark:text-red-400">
           {error}
         </p>
       )}

--- a/frontend/src/components/common/Modal.jsx
+++ b/frontend/src/components/common/Modal.jsx
@@ -39,7 +39,7 @@ function Modal({ isOpen, onClose, title, children, size = 'md', footer }) {
       <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
         {/* Background overlay */}
         <div
-          className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+          className="fixed inset-0 bg-gray-500 bg-opacity-75 dark:bg-gray-950 dark:bg-opacity-80 transition-opacity"
           aria-hidden="true"
           onClick={onClose}
         ></div>
@@ -51,17 +51,17 @@ function Modal({ isOpen, onClose, title, children, size = 'md', footer }) {
 
         {/* Modal panel */}
         <div
-          className={`inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle w-full ${sizes[size]}`}
+          className={`inline-block align-bottom bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle w-full ${sizes[size]}`}
         >
           {/* Header */}
-          <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+          <div className="bg-white dark:bg-gray-900 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
             <div className="flex items-start justify-between mb-4">
-              <h3 className="text-lg font-semibold text-gray-900" id="modal-title">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100" id="modal-title">
                 {title}
               </h3>
               <button
                 onClick={onClose}
-                className="text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-lg p-1"
+                className="text-gray-400 hover:text-gray-500 dark:hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-lg p-1"
                 aria-label="Close modal"
               >
                 <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -70,12 +70,12 @@ function Modal({ isOpen, onClose, title, children, size = 'md', footer }) {
               </button>
             </div>
             {/* Body */}
-            <div className="mt-2">{children}</div>
+            <div className="mt-2 text-gray-700 dark:text-gray-300">{children}</div>
           </div>
 
           {/* Footer */}
           {footer && (
-            <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse gap-2">
+            <div className="bg-gray-50 dark:bg-gray-800/80 border-t border-gray-200 dark:border-gray-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse gap-2">
               {footer}
             </div>
           )}

--- a/frontend/src/components/common/Select.jsx
+++ b/frontend/src/components/common/Select.jsx
@@ -6,15 +6,15 @@ const Select = forwardRef(({
   error, 
   options = [], 
   placeholder = 'Pilih...', 
-  className = '',
-  required = false,
-  disabled = false,
+  className = '', 
+  required = false, 
+  disabled = false, 
   ...props 
 }, ref) => {
   return (
     <div className={className}>
       {label && (
-        <label className="block text-sm font-medium text-gray-700 mb-1">
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
           {label}
           {required && <span className="text-red-500 ml-1">*</span>}
         </label>
@@ -24,9 +24,13 @@ const Select = forwardRef(({
         disabled={disabled}
         className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 transition-colors ${
           error 
-            ? 'border-red-300 focus:border-red-500 focus:ring-red-500' 
-            : 'border-gray-300 focus:border-blue-500 focus:ring-blue-500'
-        } ${disabled ? 'bg-gray-100 cursor-not-allowed' : 'bg-white'}`}
+            ? 'border-red-300 dark:border-red-500 focus:border-red-500 focus:ring-red-500' 
+            : 'border-gray-300 dark:border-gray-600 focus:border-blue-500 focus:ring-blue-500'
+        } ${
+          disabled 
+            ? 'bg-gray-100 dark:bg-gray-700/60 text-gray-500 dark:text-gray-400 cursor-not-allowed' 
+            : 'bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100'
+        }`}
         aria-invalid={error ? 'true' : 'false'}
         aria-describedby={error ? `${props.id}-error` : undefined}
         {...props}
@@ -39,7 +43,7 @@ const Select = forwardRef(({
         ))}
       </select>
       {error && (
-        <p id={`${props.id}-error`} className="mt-1 text-sm text-red-600">
+        <p id={`${props.id}-error`} className="mt-1 text-sm text-red-600 dark:text-red-400">
           {error}
         </p>
       )}

--- a/frontend/src/components/common/ThemeToggle.jsx
+++ b/frontend/src/components/common/ThemeToggle.jsx
@@ -1,0 +1,80 @@
+import { useTheme } from '../../contexts/ThemeContext';
+
+/**
+ * ThemeToggle Component
+ * Allows user to switch between light, dark, and system themes.
+ */
+export function ThemeToggle({ className = '' }) {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <div
+      className={`inline-flex items-center p-1 bg-gray-100 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 ${className}`}
+      role="group"
+      aria-label="Theme switcher"
+    >
+      <button
+        type="button"
+        onClick={() => setTheme('light')}
+        aria-label="Light mode"
+        title="Mode Terang"
+        className={`p-1.5 rounded-md transition-colors flex items-center justify-center ${
+          theme === 'light'
+            ? 'bg-white dark:bg-gray-700 text-amber-500 shadow-xs font-semibold'
+            : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
+        }`}
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 3v1m0 16v1m9-9h-1M4 9h-1m15.364-6.364l-.707.707M6.343 17.657l-.707.707m12.728 0l-.707-.707M6.343 6.343l-.707-.707M12 8a4 4 0 100 8 4 4 0 000-8z"
+          />
+        </svg>
+      </button>
+      <button
+        type="button"
+        onClick={() => setTheme('dark')}
+        aria-label="Dark mode"
+        title="Mode Gelap"
+        className={`p-1.5 rounded-md transition-colors flex items-center justify-center ${
+          theme === 'dark'
+            ? 'bg-white dark:bg-gray-700 text-indigo-400 shadow-xs font-semibold'
+            : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
+        }`}
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+          />
+        </svg>
+      </button>
+      <button
+        type="button"
+        onClick={() => setTheme('system')}
+        aria-label="System theme"
+        title="Ikuti Sistem"
+        className={`p-1.5 rounded-md transition-colors flex items-center justify-center ${
+          theme === 'system'
+            ? 'bg-white dark:bg-gray-700 text-blue-500 shadow-xs font-semibold'
+            : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
+        }`}
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+export default ThemeToggle;

--- a/frontend/src/components/common/index.js
+++ b/frontend/src/components/common/index.js
@@ -5,9 +5,10 @@ export { default as Button } from './Button';
 export { default as Card } from './Card';
 export { default as Empty } from './Empty';
 export { default as Input } from './Input';
+export { default as LanguageSwitcher } from './LanguageSwitcher';
 export { default as Loading } from './Loading';
 export { default as Modal } from './Modal';
 export { default as Pagination } from './Pagination';
 export { default as SearchBar } from './SearchBar';
 export { default as Select } from './Select';
-
+export { default as ThemeToggle } from './ThemeToggle';

--- a/frontend/src/contexts/ThemeContext.jsx
+++ b/frontend/src/contexts/ThemeContext.jsx
@@ -1,0 +1,111 @@
+import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+
+const ThemeContext = createContext(null);
+
+/**
+ * Custom hook to consume ThemeContext
+ */
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}
+
+/**
+ * Determine if system prefers dark mode
+ */
+function getSystemTheme() {
+  if (typeof window === 'undefined' || !window.matchMedia) {
+    return 'light';
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+/**
+ * ThemeProvider component managing light/dark/system themes
+ */
+export function ThemeProvider({ children, defaultTheme = 'system', storageKey = 'theme' }) {
+  const [theme, setThemeState] = useState(() => {
+    try {
+      return localStorage.getItem(storageKey) || defaultTheme;
+    } catch {
+      return defaultTheme;
+    }
+  });
+
+  const [resolvedTheme, setResolvedTheme] = useState(() => {
+    const initialTheme = (() => {
+      try {
+        return localStorage.getItem(storageKey) || defaultTheme;
+      } catch {
+        return defaultTheme;
+      }
+    })();
+    return initialTheme === 'system' ? getSystemTheme() : initialTheme;
+  });
+
+  const applyTheme = useCallback((effectiveTheme) => {
+    const root = document.documentElement;
+    if (effectiveTheme === 'dark') {
+      root.classList.add('dark');
+      root.setAttribute('data-theme', 'dark');
+      root.style.colorScheme = 'dark';
+    } else {
+      root.classList.remove('dark');
+      root.setAttribute('data-theme', 'light');
+      root.style.colorScheme = 'light';
+    }
+  }, []);
+
+  const setTheme = useCallback(
+    (newTheme) => {
+      setThemeState(newTheme);
+      try {
+        localStorage.setItem(storageKey, newTheme);
+      } catch (e) {
+        console.warn('Failed to save theme to localStorage:', e);
+      }
+    },
+    [storageKey]
+  );
+
+  // Synchronize applied theme with state & OS system preference
+  useEffect(() => {
+    const updateResolvedTheme = () => {
+      const active = theme === 'system' ? getSystemTheme() : theme;
+      setResolvedTheme(active);
+      applyTheme(active);
+    };
+
+    updateResolvedTheme();
+
+    if (theme !== 'system' || typeof window === 'undefined' || !window.matchMedia) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = () => {
+      updateResolvedTheme();
+    };
+
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener('change', handleChange);
+      return () => mediaQuery.removeEventListener('change', handleChange);
+    } else if (mediaQuery.addListener) {
+      mediaQuery.addListener(handleChange);
+      return () => mediaQuery.removeListener(handleChange);
+    }
+  }, [theme, applyTheme]);
+
+  const value = {
+    theme,
+    resolvedTheme,
+    setTheme,
+  };
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export default ThemeContext;

--- a/frontend/src/contexts/index.js
+++ b/frontend/src/contexts/index.js
@@ -1,3 +1,3 @@
 export { AuthProvider, useAuth } from './AuthContext';
 export { NotificationProvider, useNotification } from './NotificationContext';
-
+export { ThemeProvider, useTheme } from './ThemeContext';

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }

--- a/frontend/src/pages/BorrowingList.jsx
+++ b/frontend/src/pages/BorrowingList.jsx
@@ -150,20 +150,20 @@ function BorrowingList() {
       {/* Header */}
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Manajemen Peminjaman</h1>
-          <p className="text-gray-600 mt-1">Kelola peminjaman barang inventaris</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Manajemen Peminjaman</h1>
+          <p className="text-gray-600 dark:text-gray-400 mt-1">Kelola peminjaman barang inventaris</p>
         </div>
 
         <div className="flex flex-wrap items-center gap-3">
           {/* Dual-Mode Toggle */}
-          <div className="inline-flex bg-gray-100 p-1 rounded-lg border border-gray-200 text-xs font-medium">
+          <div className="inline-flex bg-gray-100 dark:bg-gray-800 p-1 rounded-lg border border-gray-200 dark:border-gray-700 text-xs font-medium">
             <button
               type="button"
               onClick={() => handleModeChange('pagination')}
               className={`px-3 py-1.5 rounded-md transition-all flex items-center space-x-1.5 ${
                 displayMode === 'pagination'
-                  ? 'bg-white text-gray-900 shadow-sm font-semibold'
-                  : 'text-gray-600 hover:text-gray-900'
+                  ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm font-semibold'
+                  : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100'
               }`}
               title="Mode Halaman Tradisional"
             >
@@ -177,8 +177,8 @@ function BorrowingList() {
               onClick={() => handleModeChange('infinite')}
               className={`px-3 py-1.5 rounded-md transition-all flex items-center space-x-1.5 ${
                 displayMode === 'infinite'
-                  ? 'bg-white text-blue-600 shadow-sm font-semibold'
-                  : 'text-gray-600 hover:text-gray-900'
+                  ? 'bg-white dark:bg-gray-700 text-blue-600 dark:text-blue-400 shadow-sm font-semibold'
+                  : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100'
               }`}
               title="Mode Scroll Otomatis (Infinite Scroll)"
             >
@@ -202,27 +202,27 @@ function BorrowingList() {
       </div>
 
       {/* Filters */}
-      <div className="bg-white rounded-lg shadow-sm p-4 mb-6">
+      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-800 p-4 mb-6">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           {/* Search */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Cari</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Cari</label>
             <input
               type="text"
               placeholder="Kode/User/Barang..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             />
           </div>
 
           {/* Status Filter */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Status</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Status</label>
             <select
               value={statusFilter}
               onChange={(e) => setStatusFilter(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             >
               <option value="">Semua Status</option>
               <option value="pending">Pending</option>
@@ -234,83 +234,83 @@ function BorrowingList() {
 
           {/* Start Date */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Dari Tanggal</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Dari Tanggal</label>
             <input
               type="date"
               value={startDate}
               onChange={(e) => setStartDate(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             />
           </div>
 
           {/* End Date */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Sampai Tanggal</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Sampai Tanggal</label>
             <input
               type="date"
               value={endDate}
               onChange={(e) => setEndDate(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             />
           </div>
         </div>
       </div>
 
       {/* Table */}
-      <div className="bg-white rounded-lg shadow-sm overflow-hidden">
+      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-800 overflow-hidden">
         {loading ? (
           <div className="text-center py-12">
             <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
-            <p className="mt-4 text-gray-600">Memuat data...</p>
+            <p className="mt-4 text-gray-600 dark:text-gray-400">Memuat data...</p>
           </div>
         ) : borrowings.length === 0 ? (
           <div className="text-center py-12">
-            <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
             </svg>
-            <p className="mt-4 text-gray-600">Tidak ada data peminjaman</p>
+            <p className="mt-4 text-gray-600 dark:text-gray-400">Tidak ada data peminjaman</p>
           </div>
         ) : (
           <>
             <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200">
-                <thead className="bg-gray-50">
+              <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+                <thead className="bg-gray-50 dark:bg-gray-800/60">
                   <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Kode</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Peminjam</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Barang</th>
-                    <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Qty</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tgl Pinjam</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Jatuh Tempo</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tgl Kembali</th>
-                    <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                    <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Aksi</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Kode</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Peminjam</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Barang</th>
+                    <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Qty</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Tgl Pinjam</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Jatuh Tempo</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Tgl Kembali</th>
+                    <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
+                    <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Aksi</th>
                   </tr>
                 </thead>
-                <tbody className="bg-white divide-y divide-gray-200">
+                <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-800">
                   {borrowings.map((borrowing) => (
-                    <tr key={borrowing.id} className="hover:bg-gray-50">
+                    <tr key={borrowing.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
                       <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="text-sm font-medium text-gray-900">{borrowing.code}</div>
+                        <div className="text-sm font-medium text-gray-900 dark:text-gray-100">{borrowing.code}</div>
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="text-sm text-gray-900">{borrowing.user?.name}</div>
-                        <div className="text-sm text-gray-500">{borrowing.user?.email}</div>
+                        <div className="text-sm text-gray-900 dark:text-gray-100">{borrowing.user?.name}</div>
+                        <div className="text-sm text-gray-500 dark:text-gray-400">{borrowing.user?.email}</div>
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="text-sm text-gray-900">{borrowing.item?.name}</div>
-                        <div className="text-sm text-gray-500">{borrowing.item?.code}</div>
+                        <div className="text-sm text-gray-900 dark:text-gray-100">{borrowing.item?.name}</div>
+                        <div className="text-sm text-gray-500 dark:text-gray-400">{borrowing.item?.code}</div>
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-center">
-                        <span className="text-sm font-medium text-gray-900">{borrowing.quantity}</span>
+                        <span className="text-sm font-medium text-gray-900 dark:text-gray-100">{borrowing.quantity}</span>
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">
                         {new Date(borrowing.borrow_date).toLocaleDateString('id-ID')}
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">
                         {new Date(borrowing.due_date).toLocaleDateString('id-ID')}
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">
                         {borrowing.return_date ? new Date(borrowing.return_date).toLocaleDateString('id-ID') : '-'}
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-center">
@@ -321,7 +321,7 @@ function BorrowingList() {
                       <td className="px-6 py-4 whitespace-nowrap text-center text-sm font-medium">
                         <Link
                           to={`/borrowings/${borrowing.id}`}
-                          className="text-blue-600 hover:text-blue-900 mr-3"
+                          className="text-blue-600 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300 mr-3"
                           title="Detail"
                         >
                           <svg className="w-5 h-5 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -332,7 +332,7 @@ function BorrowingList() {
                         {borrowing.status === 'approved' && (
                           <Link
                             to={`/borrowings/${borrowing.id}/return`}
-                            className="text-green-600 hover:text-green-900 mr-3"
+                            className="text-green-600 dark:text-green-400 hover:text-green-900 dark:hover:text-green-300 mr-3"
                             title="Kembalikan"
                           >
                             <svg className="w-5 h-5 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -343,7 +343,7 @@ function BorrowingList() {
                         {isAdmin && borrowing.status === 'pending' && (
                           <button
                             onClick={() => handleApprove(borrowing.id)}
-                            className="text-purple-600 hover:text-purple-900"
+                            className="text-purple-600 dark:text-purple-400 hover:text-purple-900 dark:hover:text-purple-300"
                             title="Approve"
                           >
                             <svg className="w-5 h-5 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -360,20 +360,20 @@ function BorrowingList() {
 
             {/* Mode Infinite Scroll: Sentinel / Footer Notice */}
             {displayMode === 'infinite' && (
-              <div className="bg-white px-6 py-4 border-t border-gray-200">
+              <div className="bg-white dark:bg-gray-900 px-6 py-4 border-t border-gray-200 dark:border-gray-800">
                 {currentPage < totalPages ? (
                   <div ref={sentinelRef} className="flex flex-col items-center justify-center py-2">
                     {loadingMore ? (
-                      <div className="flex items-center space-x-2 text-blue-600 text-sm font-medium">
-                        <div className="inline-block animate-spin rounded-full h-5 w-5 border-b-2 border-blue-600"></div>
+                      <div className="flex items-center space-x-2 text-blue-600 dark:text-blue-400 text-sm font-medium">
+                        <div className="inline-block animate-spin rounded-full h-5 w-5 border-b-2 border-blue-600 dark:border-blue-400"></div>
                         <span>Memuat lebih banyak peminjaman...</span>
                       </div>
                     ) : (
-                      <span className="text-xs text-gray-400">Gulir ke bawah untuk memuat lebih banyak...</span>
+                      <span className="text-xs text-gray-400 dark:text-gray-500">Gulir ke bawah untuk memuat lebih banyak...</span>
                     )}
                   </div>
                 ) : (
-                  <p className="text-center text-sm text-gray-500 py-1 font-medium">
+                  <p className="text-center text-sm text-gray-500 dark:text-gray-400 py-1 font-medium">
                     Semua peminjaman telah ditampilkan ({borrowings.length} data)
                   </p>
                 )}
@@ -382,23 +382,23 @@ function BorrowingList() {
 
             {/* Mode Pagination: Traditional Numbered Buttons */}
             {displayMode === 'pagination' && totalPages > 1 && (
-              <div className="px-6 py-4 border-t border-gray-200">
+              <div className="bg-white dark:bg-gray-900 px-4 py-3 border-t border-gray-200 dark:border-gray-800 sm:px-6">
                 <div className="flex items-center justify-between">
-                  <div className="text-sm text-gray-600">
+                  <div className="text-sm text-gray-600 dark:text-gray-400">
                     Halaman <span className="font-medium">{currentPage}</span> dari <span className="font-medium">{totalPages}</span>
                   </div>
                   <div className="flex space-x-2">
                     <button
                       onClick={() => setCurrentPage(currentPage - 1)}
                       disabled={currentPage === 1}
-                      className="px-3 py-1 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+                      className="px-3 py-1 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-sm"
                     >
                       Previous
                     </button>
                     <button
                       onClick={() => setCurrentPage(currentPage + 1)}
                       disabled={currentPage === totalPages}
-                      className="px-3 py-1 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+                      className="px-3 py-1 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-sm"
                     >
                       Next
                     </button>

--- a/frontend/src/pages/ItemList.jsx
+++ b/frontend/src/pages/ItemList.jsx
@@ -147,20 +147,20 @@ function ItemList() {
       {/* Header */}
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Manajemen Barang</h1>
-          <p className="text-gray-600 mt-1">Kelola data barang inventaris</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Manajemen Barang</h1>
+          <p className="text-gray-600 dark:text-gray-400 mt-1">Kelola data barang inventaris</p>
         </div>
 
         <div className="flex flex-wrap items-center gap-3">
           {/* Dual-Mode Toggle */}
-          <div className="inline-flex bg-gray-100 p-1 rounded-lg border border-gray-200 text-xs font-medium">
+          <div className="inline-flex bg-gray-100 dark:bg-gray-800 p-1 rounded-lg border border-gray-200 dark:border-gray-700 text-xs font-medium">
             <button
               type="button"
               onClick={() => handleModeChange('pagination')}
               className={`px-3 py-1.5 rounded-md transition-all flex items-center space-x-1.5 ${
                 displayMode === 'pagination'
-                  ? 'bg-white text-gray-900 shadow-sm font-semibold'
-                  : 'text-gray-600 hover:text-gray-900'
+                  ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm font-semibold'
+                  : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100'
               }`}
               title="Mode Halaman Tradisional"
             >
@@ -174,8 +174,8 @@ function ItemList() {
               onClick={() => handleModeChange('infinite')}
               className={`px-3 py-1.5 rounded-md transition-all flex items-center space-x-1.5 ${
                 displayMode === 'infinite'
-                  ? 'bg-white text-blue-600 shadow-sm font-semibold'
-                  : 'text-gray-600 hover:text-gray-900'
+                  ? 'bg-white dark:bg-gray-700 text-blue-600 dark:text-blue-400 shadow-sm font-semibold'
+                  : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100'
               }`}
               title="Mode Scroll Otomatis (Infinite Scroll)"
             >
@@ -199,7 +199,7 @@ function ItemList() {
       </div>
 
       {/* Filters */}
-      <div className="bg-white rounded-lg shadow-sm p-4 mb-6">
+      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-800 p-4 mb-6">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
           {/* Search */}
           <div className="md:col-span-2">
@@ -208,7 +208,7 @@ function ItemList() {
               placeholder="Cari berdasarkan nama atau kode..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             />
           </div>
 
@@ -217,7 +217,7 @@ function ItemList() {
             <select
               value={categoryFilter}
               onChange={(e) => setCategoryFilter(e.target.value)}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             >
               <option value="">Semua Kategori</option>
               {categories.map((cat) => (
@@ -233,7 +233,7 @@ function ItemList() {
             <select
               value={conditionFilter}
               onChange={(e) => setConditionFilter(e.target.value)}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             >
               <option value="">Semua Kondisi</option>
               <option value="baik">Baik</option>
@@ -245,66 +245,66 @@ function ItemList() {
       </div>
 
       {/* Table */}
-      <div className="bg-white rounded-lg shadow-sm overflow-hidden">
+      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-800 overflow-hidden">
         {loading ? (
           <div className="p-8 text-center">
             <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-            <p className="mt-2 text-gray-600">Memuat data...</p>
+            <p className="mt-2 text-gray-600 dark:text-gray-400">Memuat data...</p>
           </div>
         ) : items.length === 0 ? (
           <div className="p-8 text-center">
-            <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
             </svg>
-            <p className="mt-2 text-gray-600">Tidak ada data barang</p>
+            <p className="mt-2 text-gray-600 dark:text-gray-400">Tidak ada data barang</p>
           </div>
         ) : (
           <>
-            <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
+            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+              <thead className="bg-gray-50 dark:bg-gray-800/60">
                 <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Kode
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Nama Barang
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Kategori
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Stok
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Tersedia
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Kondisi
                   </th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Aksi
                   </th>
                 </tr>
               </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
+              <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-800">
                 {items.map((item) => (
-                  <tr key={item.id} className="hover:bg-gray-50">
-                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                  <tr key={item.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">
                       {item.code}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm font-medium text-gray-900">{item.name}</div>
-                      <div className="text-sm text-gray-500">{item.description?.substring(0, 50)}</div>
+                      <div className="text-sm font-medium text-gray-900 dark:text-gray-100">{item.name}</div>
+                      <div className="text-sm text-gray-500 dark:text-gray-400">{item.description?.substring(0, 50)}</div>
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                       {item.category?.name}
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
                       {item.stock}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <span className={`px-2 py-1 text-xs font-semibold rounded-full ${
-                        item.available_stock > 0 ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+                        item.available_stock > 0 ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300' : 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300'
                       }`}>
                         {item.available_stock}
                       </span>
@@ -317,19 +317,19 @@ function ItemList() {
                     <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                       <Link
                         to={`/items/${item.id}`}
-                        className="text-blue-600 hover:text-blue-900 mr-3"
+                        className="text-blue-600 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300 mr-3"
                       >
                         Detail
                       </Link>
                       <Link
                         to={`/items/${item.id}/edit`}
-                        className="text-indigo-600 hover:text-indigo-900 mr-3"
+                        className="text-indigo-600 dark:text-indigo-400 hover:text-indigo-900 dark:hover:text-indigo-300 mr-3"
                       >
                         Edit
                       </Link>
                       <button
                         onClick={() => handleDelete(item.id)}
-                        className="text-red-600 hover:text-red-900"
+                        className="text-red-600 dark:text-red-400 hover:text-red-900 dark:hover:text-red-300"
                       >
                         Hapus
                       </button>
@@ -341,20 +341,20 @@ function ItemList() {
 
             {/* Mode Infinite Scroll: Sentinel / Footer Notice */}
             {displayMode === 'infinite' && (
-              <div className="bg-white px-6 py-4 border-t border-gray-200">
+              <div className="bg-white dark:bg-gray-900 px-6 py-4 border-t border-gray-200 dark:border-gray-800">
                 {currentPage < totalPages ? (
                   <div ref={sentinelRef} className="flex flex-col items-center justify-center py-2">
                     {loadingMore ? (
-                      <div className="flex items-center space-x-2 text-blue-600 text-sm font-medium">
-                        <div className="inline-block animate-spin rounded-full h-5 w-5 border-b-2 border-blue-600"></div>
+                      <div className="flex items-center space-x-2 text-blue-600 dark:text-blue-400 text-sm font-medium">
+                        <div className="inline-block animate-spin rounded-full h-5 w-5 border-b-2 border-blue-600 dark:border-blue-400"></div>
                         <span>Memuat lebih banyak barang...</span>
                       </div>
                     ) : (
-                      <span className="text-xs text-gray-400">Gulir ke bawah untuk memuat lebih banyak...</span>
+                      <span className="text-xs text-gray-400 dark:text-gray-500">Gulir ke bawah untuk memuat lebih banyak...</span>
                     )}
                   </div>
                 ) : (
-                  <p className="text-center text-sm text-gray-500 py-1 font-medium">
+                  <p className="text-center text-sm text-gray-500 dark:text-gray-400 py-1 font-medium">
                     Semua barang telah ditampilkan ({items.length} data)
                   </p>
                 )}
@@ -363,26 +363,26 @@ function ItemList() {
 
             {/* Mode Pagination: Traditional Numbered Buttons */}
             {displayMode === 'pagination' && totalPages > 1 && (
-              <div className="bg-white px-4 py-3 flex items-center justify-between border-t border-gray-200 sm:px-6">
+              <div className="bg-white dark:bg-gray-900 px-4 py-3 flex items-center justify-between border-t border-gray-200 dark:border-gray-800 sm:px-6">
                 <div className="flex-1 flex justify-between sm:hidden">
                   <button
                     onClick={() => setCurrentPage(Math.max(1, currentPage - 1))}
                     disabled={currentPage === 1}
-                    className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50"
+                    className="relative inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-700 text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
                   >
                     Previous
                   </button>
                   <button
                     onClick={() => setCurrentPage(Math.min(totalPages, currentPage + 1))}
                     disabled={currentPage === totalPages}
-                    className="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50"
+                    className="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-700 text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
                   >
                     Next
                   </button>
                 </div>
                 <div className="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
                   <div>
-                    <p className="text-sm text-gray-700">
+                    <p className="text-sm text-gray-700 dark:text-gray-300">
                       Halaman <span className="font-medium">{currentPage}</span> dari{' '}
                       <span className="font-medium">{totalPages}</span>
                     </p>
@@ -392,7 +392,7 @@ function ItemList() {
                       <button
                         onClick={() => setCurrentPage(Math.max(1, currentPage - 1))}
                         disabled={currentPage === 1}
-                        className="relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50"
+                        className="relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm font-medium text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
                       >
                         <span className="sr-only">Previous</span>
                         <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
@@ -403,10 +403,10 @@ function ItemList() {
                         <button
                           key={i + 1}
                           onClick={() => setCurrentPage(i + 1)}
-                          className={`relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium ${
+                          className={`relative inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-700 text-sm font-medium ${
                             currentPage === i + 1
-                              ? 'z-10 bg-blue-50 border-blue-500 text-blue-600'
-                              : 'bg-white text-gray-700 hover:bg-gray-50'
+                              ? 'z-10 bg-blue-50 dark:bg-blue-950/50 border-blue-500 text-blue-600 dark:text-blue-400'
+                              : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
                           }`}
                         >
                           {i + 1}
@@ -415,7 +415,7 @@ function ItemList() {
                       <button
                         onClick={() => setCurrentPage(Math.min(totalPages, currentPage + 1))}
                         disabled={currentPage === totalPages}
-                        className="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50"
+                        className="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm font-medium text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
                       >
                         <span className="sr-only">Next</span>
                         <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">

--- a/frontend/src/test/contexts/ThemeContext.test.jsx
+++ b/frontend/src/test/contexts/ThemeContext.test.jsx
@@ -1,0 +1,153 @@
+import { act, render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ThemeToggle from '../../components/common/ThemeToggle';
+import { ThemeProvider, useTheme } from '../../contexts/ThemeContext';
+
+describe('ThemeContext & ThemeProvider', () => {
+  let originalMatchMedia;
+  let matchMediaListeners = [];
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = '';
+    document.documentElement.removeAttribute('data-theme');
+    document.documentElement.style.colorScheme = '';
+
+    matchMediaListeners = [];
+    originalMatchMedia = window.matchMedia;
+
+    window.matchMedia = vi.fn((query) => ({
+      matches: false, // default light in system mock
+      media: query,
+      onchange: null,
+      addListener: vi.fn((listener) => matchMediaListeners.push(listener)),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn((_, listener) => matchMediaListeners.push(listener)),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+    localStorage.clear();
+    document.documentElement.className = '';
+    vi.clearAllMocks();
+  });
+
+  it('throws error when useTheme is used outside ThemeProvider', () => {
+    // Suppress console.error for expected thrown error
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => renderHook(() => useTheme())).toThrow(
+      'useTheme must be used within a ThemeProvider'
+    );
+    spy.mockRestore();
+  });
+
+  it('provides default theme as system and resolves according to matchMedia', () => {
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ({ children }) => <ThemeProvider>{children}</ThemeProvider>,
+    });
+
+    expect(result.current.theme).toBe('system');
+    expect(result.current.resolvedTheme).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('applies dark class and stores in localStorage when theme is set to dark', () => {
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ({ children }) => <ThemeProvider>{children}</ThemeProvider>,
+    });
+
+    act(() => {
+      result.current.setTheme('dark');
+    });
+
+    expect(result.current.theme).toBe('dark');
+    expect(result.current.resolvedTheme).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(document.documentElement.style.colorScheme).toBe('dark');
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('removes dark class when theme is switched from dark to light', () => {
+    localStorage.setItem('theme', 'dark');
+
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ({ children }) => <ThemeProvider>{children}</ThemeProvider>,
+    });
+
+    expect(result.current.theme).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+
+    act(() => {
+      result.current.setTheme('light');
+    });
+
+    expect(result.current.theme).toBe('light');
+    expect(result.current.resolvedTheme).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(document.documentElement.style.colorScheme).toBe('light');
+    expect(localStorage.getItem('theme')).toBe('light');
+  });
+
+  it('resolves to dark when theme is system and system prefers dark', () => {
+    window.matchMedia = vi.fn((query) => ({
+      matches: true,
+      media: query,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ({ children }) => <ThemeProvider>{children}</ThemeProvider>,
+    });
+
+    expect(result.current.theme).toBe('system');
+    expect(result.current.resolvedTheme).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('allows ThemeToggle to switch themes on button clicks', async () => {
+    const user = userEvent.setup();
+
+    function TestApp() {
+      const { theme } = useTheme();
+      return (
+        <div>
+          <ThemeToggle />
+          <span data-testid="current-theme">{theme}</span>
+        </div>
+      );
+    }
+
+    render(
+      <ThemeProvider>
+        <TestApp />
+      </ThemeProvider>
+    );
+
+    const lightBtn = screen.getByRole('button', { name: /light mode/i });
+    const darkBtn = screen.getByRole('button', { name: /dark mode/i });
+    const systemBtn = screen.getByRole('button', { name: /system theme/i });
+
+    // Switch to dark
+    await user.click(darkBtn);
+    expect(screen.getByTestId('current-theme')).toHaveTextContent('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+
+    // Switch to light
+    await user.click(lightBtn);
+    expect(screen.getByTestId('current-theme')).toHaveTextContent('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+
+    // Switch to system
+    await user.click(systemBtn);
+    expect(screen.getByTestId('current-theme')).toHaveTextContent('system');
+  });
+});


### PR DESCRIPTION
## Summary of Changes
Implements comprehensive dark mode support and a persistent theme switcher for the frontend application (Closes #65).

### Key Implementations:
1. **Tailwind CSS v4 Dark Variant**:
   - Added `@custom-variant dark (&:where(.dark, .dark *));` to `frontend/src/index.css`.
2. **ThemeContext & State Management** (`frontend/src/contexts/ThemeContext.jsx`):
   - Tri-state theme selection: `'light'`, `'dark'`, and `'system'`.
   - Dynamic evaluation of OS dark mode using `window.matchMedia('(prefers-color-scheme: dark)')` with real-time change listener.
   - Synchronizes `<html>` class (`dark`), `data-theme`, and `colorScheme`.
   - Persists user preferences in `localStorage`.
3. **ThemeToggle Component** (`frontend/src/components/common/ThemeToggle.jsx`):
   - Pill toggle button in `Header.jsx` allowing instant selection between light, dark, and system modes.
4. **Theme Harmonization Across Layout & Common Components**:
   - `Layout.jsx` & `Sidebar.jsx`: Dark backgrounds, subtle borders, and appropriate contrast.
   - `Card.jsx`, `Input.jsx`, `Select.jsx`, `Modal.jsx`: Full dark mode styling.
   - `ItemList.jsx` & `BorrowingList.jsx`: Table, filter bar, badge, and pagination styling in dark mode.
5. **Unit Tests**:
   - Added `frontend/src/test/contexts/ThemeContext.test.jsx` covering context initialization, toggle interactions, media query resolution, and storage persistence.

### Verification:
- `npm test --prefix frontend -- --run` (48/48 tests passing)
- `npm run build --prefix frontend` (Production build completed in ~4s with 0 errors)
- `php vendor/phpunit/phpunit/phpunit tests/Feature/ItemCachingIntegrationTest.php` (6/6 passing)
