### PR TITLE
feat(ui): implement responsive layout and mobile navigation drawer (F17)

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,8 +1,9 @@
+import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import { authService } from '../services/authService';
 import ThemeToggle from './common/ThemeToggle';
 
-function Header() {
+function Header({ onToggleSidebar }) {
   const navigate = useNavigate();
   const user = authService.getCurrentUser();
 
@@ -21,17 +22,28 @@ function Header() {
 
   return (
     <header className="bg-white dark:bg-gray-900 shadow-xs border-b border-gray-200 dark:border-gray-800 transition-colors">
-      <div className="px-6 py-4">
+      <div className="px-4 sm:px-6 py-3 sm:py-4">
         <div className="flex items-center justify-between">
-          {/* Breadcrumb / Page Title */}
-          <div>
-            <h2 className="text-2xl font-semibold text-gray-800 dark:text-gray-100">
+          {/* Left: Hamburger (mobile) & Page Title */}
+          <div className="flex items-center space-x-2 sm:space-x-3">
+            <button
+              type="button"
+              onClick={onToggleSidebar}
+              className="p-2 -ml-2 rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none md:hidden transition-colors"
+              aria-label="Buka menu navigasi"
+              data-testid="hamburger-button"
+            >
+              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            </button>
+            <h2 className="text-xl sm:text-2xl font-semibold text-gray-800 dark:text-gray-100">
               {/* This will be replaced by page-specific title */}
             </h2>
           </div>
 
           {/* Right side - User menu & Theme switcher */}
-          <div className="flex items-center space-x-4">
+          <div className="flex items-center space-x-2 sm:space-x-4">
             {/* Theme Toggle */}
             <ThemeToggle />
 
@@ -46,14 +58,14 @@ function Header() {
 
             {/* User dropdown */}
             <div className="relative group">
-              <button className="flex items-center space-x-3 px-3 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
-                <div className="w-8 h-8 rounded-full bg-blue-600 flex items-center justify-center">
+              <button className="flex items-center space-x-2 sm:space-x-3 px-2 sm:px-3 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+                <div className="w-8 h-8 rounded-full bg-blue-600 flex items-center justify-center shrink-0">
                   <span className="text-sm font-semibold text-white">
                     {user?.name?.charAt(0)}
                   </span>
                 </div>
-                <div className="text-left">
-                  <p className="text-sm font-medium text-gray-700 dark:text-gray-200">{user?.name}</p>
+                <div className="text-left hidden sm:block">
+                  <p className="text-sm font-medium text-gray-700 dark:text-gray-200 truncate max-w-30">{user?.name}</p>
                   <p className="text-xs text-gray-500 dark:text-gray-400 capitalize">{user?.role}</p>
                 </div>
                 <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -116,5 +128,9 @@ function Header() {
     </header>
   );
 }
+
+Header.propTypes = {
+  onToggleSidebar: PropTypes.func,
+};
 
 export default Header;

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,21 +1,27 @@
+import { useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import Header from './Header';
 import Sidebar from './Sidebar';
 
 function Layout() {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+  const toggleSidebar = () => setIsSidebarOpen((prev) => !prev);
+  const closeSidebar = () => setIsSidebarOpen(false);
+
   return (
     <div className="flex h-screen bg-gray-100 dark:bg-gray-950 transition-colors">
-      {/* Sidebar */}
-      <Sidebar />
+      {/* Sidebar with mobile drawer support */}
+      <Sidebar isOpen={isSidebarOpen} onClose={closeSidebar} />
 
       {/* Main Content */}
-      <div className="flex-1 flex flex-col overflow-hidden">
+      <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
         {/* Header */}
-        <Header />
+        <Header onToggleSidebar={toggleSidebar} />
 
         {/* Page Content */}
         <main className="flex-1 overflow-x-hidden overflow-y-auto bg-gray-100 dark:bg-gray-950 text-gray-900 dark:text-gray-100 transition-colors">
-          <div className="container mx-auto px-6 py-8">
+          <div className="container mx-auto px-4 sm:px-6 py-4 sm:py-8">
             <Outlet />
           </div>
         </main>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,9 +1,16 @@
+import PropTypes from 'prop-types';
 import { NavLink } from 'react-router-dom';
 import { authService } from '../services/authService';
 
-function Sidebar() {
+function Sidebar({ isOpen = false, onClose }) {
   const user = authService.getCurrentUser();
   const isAdmin = authService.isAdmin();
+
+  const handleNavClick = () => {
+    if (onClose) {
+      onClose();
+    }
+  };
 
   const menuItems = [
     {
@@ -66,54 +73,91 @@ function Sidebar() {
   }
 
   return (
-    <div className="w-64 bg-gray-800 dark:bg-gray-900 text-white min-h-screen flex flex-col border-r border-gray-700 dark:border-gray-800 transition-colors">
-      {/* Logo */}
-      <div className="p-4 border-b border-gray-700 dark:border-gray-800">
-        <h1 className="text-xl font-bold">Sistem Inventaris</h1>
-        <p className="text-xs text-gray-400 mt-1">Peminjaman Barang</p>
-      </div>
+    <>
+      {/* Mobile Backdrop Overlay */}
+      {isOpen && (
+        <div
+          className="fixed inset-0 bg-black/50 z-40 md:hidden backdrop-blur-xs transition-opacity"
+          onClick={onClose}
+          aria-hidden="true"
+          data-testid="sidebar-backdrop"
+        />
+      )}
 
-      {/* User Info */}
-      <div className="p-4 border-b border-gray-700 dark:border-gray-800">
-        <div className="flex items-center space-x-3">
-          <div className="w-10 h-10 rounded-full bg-gray-600 dark:bg-gray-700 flex items-center justify-center">
-            <span className="text-lg font-semibold">{user?.name?.charAt(0)}</span>
+      {/* Sidebar / Off-canvas Drawer */}
+      <aside
+        className={`fixed inset-y-0 left-0 z-50 w-64 bg-gray-800 dark:bg-gray-900 text-white min-h-screen flex flex-col border-r border-gray-700 dark:border-gray-800 transition-transform duration-300 ease-in-out md:static md:translate-x-0 ${
+          isOpen ? 'translate-x-0' : '-translate-x-full'
+        }`}
+        data-testid="sidebar"
+      >
+        {/* Logo & Mobile Close Button */}
+        <div className="p-4 border-b border-gray-700 dark:border-gray-800 flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-bold">Sistem Inventaris</h1>
+            <p className="text-xs text-gray-400 mt-1">Peminjaman Barang</p>
           </div>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium truncate">{user?.name}</p>
-            <p className="text-xs text-gray-400 capitalize">{user?.role}</p>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1.5 rounded-lg text-gray-400 hover:text-white hover:bg-gray-700 md:hidden transition-colors"
+            aria-label="Tutup menu navigasi"
+            data-testid="sidebar-close-button"
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* User Info */}
+        <div className="p-4 border-b border-gray-700 dark:border-gray-800">
+          <div className="flex items-center space-x-3">
+            <div className="w-10 h-10 rounded-full bg-gray-600 dark:bg-gray-700 flex items-center justify-center shrink-0">
+              <span className="text-lg font-semibold">{user?.name?.charAt(0)}</span>
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium truncate">{user?.name}</p>
+              <p className="text-xs text-gray-400 capitalize">{user?.role}</p>
+            </div>
           </div>
         </div>
-      </div>
 
-      {/* Navigation */}
-      <nav className="flex-1 p-4 space-y-1">
-        {menuItems.map((item) => (
-          <NavLink
-            key={item.path}
-            to={item.path}
-            className={({ isActive }) =>
-              `flex items-center space-x-3 px-4 py-3 rounded-lg transition-colors ${
-                isActive
-                  ? 'bg-blue-600 text-white'
-                  : 'text-gray-300 hover:bg-gray-700 dark:hover:bg-gray-800 hover:text-white'
-              }`
-            }
-          >
-            {item.icon}
-            <span className="font-medium">{item.name}</span>
-          </NavLink>
-        ))}
-      </nav>
+        {/* Navigation */}
+        <nav className="flex-1 p-4 space-y-1 overflow-y-auto">
+          {menuItems.map((item) => (
+            <NavLink
+              key={item.path}
+              to={item.path}
+              onClick={handleNavClick}
+              className={({ isActive }) =>
+                `flex items-center space-x-3 px-4 py-3 rounded-lg transition-colors ${
+                  isActive
+                    ? 'bg-blue-600 text-white'
+                    : 'text-gray-300 hover:bg-gray-700 dark:hover:bg-gray-800 hover:text-white'
+                }`
+              }
+            >
+              {item.icon}
+              <span className="font-medium">{item.name}</span>
+            </NavLink>
+          ))}
+        </nav>
 
-      {/* Footer */}
-      <div className="p-4 border-t border-gray-700 dark:border-gray-800">
-        <p className="text-xs text-gray-400 text-center">
-          © 2026 Sistem Inventaris
-        </p>
-      </div>
-    </div>
+        {/* Footer */}
+        <div className="p-4 border-t border-gray-700 dark:border-gray-800">
+          <p className="text-xs text-gray-400 text-center">
+            © 2026 Sistem Inventaris
+          </p>
+        </div>
+      </aside>
+    </>
   );
 }
+
+Sidebar.propTypes = {
+  isOpen: PropTypes.bool,
+  onClose: PropTypes.func,
+};
 
 export default Sidebar;

--- a/frontend/src/pages/ItemList.jsx
+++ b/frontend/src/pages/ItemList.jsx
@@ -200,9 +200,9 @@ function ItemList() {
 
       {/* Filters */}
       <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-800 p-4 mb-6">
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
           {/* Search */}
-          <div className="md:col-span-2">
+          <div className="sm:col-span-2">
             <input
               type="text"
               placeholder="Cari berdasarkan nama atau kode..."
@@ -260,84 +260,86 @@ function ItemList() {
           </div>
         ) : (
           <>
-            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
-              <thead className="bg-gray-50 dark:bg-gray-800/60">
-                <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Kode
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Nama Barang
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Kategori
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Stok
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Tersedia
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Kondisi
-                  </th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Aksi
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-800">
-                {items.map((item) => (
-                  <tr key={item.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
-                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">
-                      {item.code}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm font-medium text-gray-900 dark:text-gray-100">{item.name}</div>
-                      <div className="text-sm text-gray-500 dark:text-gray-400">{item.description?.substring(0, 50)}</div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
-                      {item.category?.name}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
-                      {item.stock}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <span className={`px-2 py-1 text-xs font-semibold rounded-full ${
-                        item.available_stock > 0 ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300' : 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300'
-                      }`}>
-                        {item.available_stock}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <span className={`px-2 py-1 text-xs font-semibold rounded-full ${getConditionBadge(item.condition)}`}>
-                        {item.condition}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                      <Link
-                        to={`/items/${item.id}`}
-                        className="text-blue-600 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300 mr-3"
-                      >
-                        Detail
-                      </Link>
-                      <Link
-                        to={`/items/${item.id}/edit`}
-                        className="text-indigo-600 dark:text-indigo-400 hover:text-indigo-900 dark:hover:text-indigo-300 mr-3"
-                      >
-                        Edit
-                      </Link>
-                      <button
-                        onClick={() => handleDelete(item.id)}
-                        className="text-red-600 dark:text-red-400 hover:text-red-900 dark:hover:text-red-300"
-                      >
-                        Hapus
-                      </button>
-                    </td>
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+                <thead className="bg-gray-50 dark:bg-gray-800/60">
+                  <tr>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Kode
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Nama Barang
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Kategori
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Stok
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Tersedia
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Kondisi
+                    </th>
+                    <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Aksi
+                    </th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-800">
+                  {items.map((item) => (
+                    <tr key={item.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">
+                        {item.code}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm font-medium text-gray-900 dark:text-gray-100">{item.name}</div>
+                        <div className="text-sm text-gray-500 dark:text-gray-400">{item.description?.substring(0, 50)}</div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                        {item.category?.name}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                        {item.stock}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <span className={`px-2 py-1 text-xs font-semibold rounded-full ${
+                          item.available_stock > 0 ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300' : 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300'
+                        }`}>
+                          {item.available_stock}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <span className={`px-2 py-1 text-xs font-semibold rounded-full ${getConditionBadge(item.condition)}`}>
+                          {item.condition}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                        <Link
+                          to={`/items/${item.id}`}
+                          className="text-blue-600 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300 mr-3"
+                        >
+                          Detail
+                        </Link>
+                        <Link
+                          to={`/items/${item.id}/edit`}
+                          className="text-indigo-600 dark:text-indigo-400 hover:text-indigo-900 dark:hover:text-indigo-300 mr-3"
+                        >
+                          Edit
+                        </Link>
+                        <button
+                          onClick={() => handleDelete(item.id)}
+                          className="text-red-600 dark:text-red-400 hover:text-red-900 dark:hover:text-red-300"
+                        >
+                          Hapus
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
 
             {/* Mode Infinite Scroll: Sentinel / Footer Notice */}
             {displayMode === 'infinite' && (

--- a/frontend/src/test/components/ResponsiveLayout.test.jsx
+++ b/frontend/src/test/components/ResponsiveLayout.test.jsx
@@ -1,0 +1,122 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Layout from '../../components/Layout';
+import { ThemeProvider } from '../../contexts/ThemeContext';
+import { authService } from '../../services/authService';
+
+vi.mock('../../services/authService', () => ({
+  authService: {
+    getCurrentUser: vi.fn(),
+    isAdmin: vi.fn(),
+    logout: vi.fn(),
+  },
+}));
+
+describe('Responsive Layout & Mobile Navigation Drawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authService.getCurrentUser.mockReturnValue({
+      name: 'Budi Santoso',
+      role: 'admin',
+    });
+    authService.isAdmin.mockReturnValue(true);
+  });
+
+  const renderLayout = () => {
+    return render(
+      <ThemeProvider>
+        <MemoryRouter initialEntries={['/dashboard']}>
+          <Layout />
+        </MemoryRouter>
+      </ThemeProvider>
+    );
+  };
+
+  it('renders hamburger button in header and sidebar with closed state initially on mobile', () => {
+    renderLayout();
+
+    const hamburgerBtn = screen.getByTestId('hamburger-button');
+    expect(hamburgerBtn).toBeInTheDocument();
+    expect(hamburgerBtn).toHaveClass('md:hidden');
+
+    const sidebar = screen.getByTestId('sidebar');
+    expect(sidebar).toBeInTheDocument();
+    expect(sidebar).toHaveClass('-translate-x-full');
+    expect(sidebar).toHaveClass('md:translate-x-0');
+
+    // Backdrop should not be present initially
+    expect(screen.queryByTestId('sidebar-backdrop')).not.toBeInTheDocument();
+  });
+
+  it('opens sidebar drawer and displays backdrop overlay when hamburger button is clicked', async () => {
+    const user = userEvent.setup();
+    renderLayout();
+
+    const hamburgerBtn = screen.getByTestId('hamburger-button');
+    await user.click(hamburgerBtn);
+
+    const sidebar = screen.getByTestId('sidebar');
+    expect(sidebar).toHaveClass('translate-x-0');
+
+    const backdrop = screen.getByTestId('sidebar-backdrop');
+    expect(backdrop).toBeInTheDocument();
+  });
+
+  it('closes mobile drawer when clicking the close button inside sidebar', async () => {
+    const user = userEvent.setup();
+    renderLayout();
+
+    const hamburgerBtn = screen.getByTestId('hamburger-button');
+    await user.click(hamburgerBtn);
+
+    const closeBtn = screen.getByTestId('sidebar-close-button');
+    expect(closeBtn).toBeInTheDocument();
+
+    await user.click(closeBtn);
+
+    const sidebar = screen.getByTestId('sidebar');
+    expect(sidebar).toHaveClass('-translate-x-full');
+    expect(screen.queryByTestId('sidebar-backdrop')).not.toBeInTheDocument();
+  });
+
+  it('closes mobile drawer when clicking the backdrop overlay', async () => {
+    const user = userEvent.setup();
+    renderLayout();
+
+    // Open sidebar
+    const hamburgerBtn = screen.getByTestId('hamburger-button');
+    await user.click(hamburgerBtn);
+
+    const backdrop = screen.getByTestId('sidebar-backdrop');
+    expect(backdrop).toBeInTheDocument();
+
+    // Click backdrop to dismiss
+    await user.click(backdrop);
+
+    const sidebar = screen.getByTestId('sidebar');
+    expect(sidebar).toHaveClass('-translate-x-full');
+    expect(screen.queryByTestId('sidebar-backdrop')).not.toBeInTheDocument();
+  });
+
+  it('automatically closes mobile drawer when a navigation link is clicked', async () => {
+    const user = userEvent.setup();
+    renderLayout();
+
+    // Open sidebar
+    const hamburgerBtn = screen.getByTestId('hamburger-button');
+    await user.click(hamburgerBtn);
+
+    const sidebar = screen.getByTestId('sidebar');
+    expect(sidebar).toHaveClass('translate-x-0');
+
+    // Click a navigation item, e.g., 'Kategori'
+    const categoryLink = screen.getByRole('link', { name: /kategori/i });
+    await user.click(categoryLink);
+
+    // Sidebar should close
+    expect(sidebar).toHaveClass('-translate-x-full');
+    expect(screen.queryByTestId('sidebar-backdrop')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Ringkasan Perubahan
Pull request ini mengimplementasikan tata letak responsif dan navigasi off-canvas mobile drawer untuk perangkat ponsel dan tablet (layar < 768px), memenuhi spesifikasi task F17 pada Issue #67.

## Detail Perubahan

1. **Mobile Drawer Navigation (`Layout.jsx`, `Header.jsx`, `Sidebar.jsx`)**:
   - `Layout.jsx`: Menambahkan state `isSidebarOpen` beserta fungsi `toggleSidebar` dan `closeSidebar`. Menambahkan `min-w-0` pada flex container konten utama untuk mencegah overflow horizontal pada tabel/konten lebar. Menyesuaikan padding kontainer menjadi `px-4 sm:px-6 py-4 sm:py-8`.
   - `Header.jsx`: Menambahkan tombol hamburger menu (`md:hidden`) dengan `data-testid="hamburger-button"` dan `aria-label="Buka menu navigasi"`. Menyesuaikan padding header (`px-4 sm:px-6 py-3 sm:py-4`) dan menyembunyikan label nama pengguna pada layar sangat kecil agar header tetap rapi. Menambahkan validasi `PropTypes`.
   - `Sidebar.jsx`: Mengubah sidebar menjadi off-canvas drawer pada mobile dengan kelas `fixed inset-y-0 left-0 z-50 transition-transform duration-300 ease-in-out md:static md:translate-x-0`. Menambahkan backdrop overlay gelap (`fixed inset-0 bg-black/50 z-40 md:hidden backdrop-blur-xs`) dengan `data-testid="sidebar-backdrop"`. Menambahkan tombol tutup (X) pada header sidebar mobile (`data-testid="sidebar-close-button"`). Menambahkan event handler pada `NavLink` agar drawer menutup otomatis saat pengguna memilih menu.
2. **Responsivitas Halaman & Konten (`ItemList.jsx`)**:
   - Membungkus tabel dengan `<div className="overflow-x-auto">` agar pengguna mobile dapat menggulir data tabel secara horizontal tanpa merusak layout halaman.
   - Mengoptimalkan filter grid menjadi `grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4` dengan input pencarian `sm:col-span-2`.
3. **Pengujian Unit Frontend (`ResponsiveLayout.test.jsx`)**:
   - Menambahkan 5 skenario pengujian unit untuk memastikan:
     - Render awal desktop (hamburger disembunyikan via `md:hidden`, sidebar tertutup di mobile).
     - Tombol hamburger membuka mobile drawer dan menampilkan backdrop.
     - Tombol close (X) di dalam sidebar menutup drawer.
     - Klik pada backdrop overlay menutup drawer.
     - Klik pada tautan navigasi menutup drawer secara otomatis.

## Hasil Pengujian
- Test Unit Frontend: Vitest lulus 53/53 tests (6 test files, 100%).
- Frontend Production Build: `npm run build` sukses dalam 6.51 detik tanpa error.

Closes #67
