### PR TITLE
fix(docker): resolve host port conflicts and provider cache isolation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,8 @@ RUN chown -R www-data:www-data /var/www \
     && chmod -R 755 /var/www \
     && chmod -R 775 /var/www/storage /var/www/bootstrap/cache
 
-# Install PHP dependencies without dev and without scripts (avoids database lookup during build)
-RUN composer install --no-dev --optimize-autoloader --no-interaction --no-scripts
+# Install PHP dependencies without scripts (avoids database lookup during build)
+RUN composer install --optimize-autoloader --no-interaction --no-scripts
 
 # Expose port
 EXPOSE 80

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,6 +1,11 @@
 <?php
 
-return [
+$providers = [
     App\Providers\AppServiceProvider::class,
-    App\Providers\TelescopeServiceProvider::class,
 ];
+
+if (class_exists(\Laravel\Telescope\TelescopeApplicationServiceProvider::class)) {
+    $providers[] = App\Providers\TelescopeServiceProvider::class;
+}
+
+return $providers;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     volumes:
       - ./:/var/www
       - /var/www/vendor
+      - /var/www/bootstrap/cache
       - ./docker/nginx/default.conf:/etc/nginx/sites-available/default
       - ./docker/supervisor/supervisord.conf:/etc/supervisor/conf.d/supervisord.conf
     environment:
@@ -60,7 +61,7 @@ services:
     container_name: inventaris-db
     restart: unless-stopped
     ports:
-      - "3306:3306"
+      - "${FORWARD_DB_PORT:-3307}:3306"
     environment:
       MYSQL_DATABASE: inventaris
       MYSQL_ROOT_PASSWORD: secret
@@ -96,7 +97,7 @@ services:
     container_name: inventaris-phpmyadmin
     restart: unless-stopped
     ports:
-      - "8080:80"
+      - "${FORWARD_PMA_PORT:-8081}:80"
     environment:
       PMA_HOST: db
       PMA_PORT: 3306

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,6 +13,9 @@ mkdir -p /var/www/storage/framework/cache/data \
 chown -R www-data:www-data /var/www/storage /var/www/bootstrap/cache
 chmod -R 775 /var/www/storage /var/www/bootstrap/cache
 
+# Remove any stale package or service cache files mounted from host
+rm -f /var/www/bootstrap/cache/*.php
+
 # Wait for database if DB_HOST is set
 if [ -n "$DB_HOST" ] && [ "$DB_CONNECTION" = "mysql" ]; then
     echo "==> Waiting for database at $DB_HOST:${DB_PORT:-3306}..."


### PR DESCRIPTION
## Ringkasan Perubahan
Perbaikan lanjutan konfigurasi Docker runtime:
1. Memetakan port host MySQL ke \3307:3306\ (\\:3306\) untuk mencegah error alokasi port saat port 3306 digunakan oleh layanan MySQL/WSL pada host machine.
2. Memetakan port host PhpMyAdmin ke \8081:80\ (\\:80\) untuk menghindari konflik dengan web server lokal (Apache/httpd) pada port 8080.
3. Menambahkan pengaman \class_exists\ pada \ootstrap/providers.php\ sebelum memuat \TelescopeServiceProvider\.
4. Menambahkan anonymous volume untuk \/var/www/bootstrap/cache\ dan pembersihan cache otomatis di \ntrypoint.sh\ agar cache provider host tidak menimpa autoloader container.
5. Memasang dependensi pengembangan pada Dockerfile untuk mendukung seluruh fungsionalitas lokal (Telescope, worker, dan migrasi).

## Hasil Validasi
- Seluruh 5 container (\inventaris-app\, \inventaris-db\, \inventaris-frontend\, \inventaris-phpmyadmin\, \inventaris-redis\) berstatus UP dan healthy.
- Endpoint API dan login berjalan sukses (\http://localhost:8000/api/auth/login\).
- Frontend SPA berjalan sukses (\http://localhost:5173\).
- Database termigrasi dan terseed penuh.