### PR TITLE
feat(ui): enforce role-based access control UI visibility for staff on items and categories

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -38,6 +38,14 @@ function ProtectedRoute({ children }) {
   return children;
 }
 
+// Admin Route Component
+function AdminRoute({ children }) {
+  if (!authService.isAdmin()) {
+    return <Navigate to="/dashboard" replace />;
+  }
+  return children;
+}
+
 // Suspense wrapper for lazy loaded routes
 function SuspenseWrapper({ children }) {
   return (
@@ -73,9 +81,23 @@ function App() {
               
               {/* Items Routes */}
               <Route path="items" element={<SuspenseWrapper><ItemList /></SuspenseWrapper>} />
-              <Route path="items/create" element={<SuspenseWrapper><ItemForm /></SuspenseWrapper>} />
+              <Route
+                path="items/create"
+                element={
+                  <AdminRoute>
+                    <SuspenseWrapper><ItemForm /></SuspenseWrapper>
+                  </AdminRoute>
+                }
+              />
               <Route path="items/:id" element={<SuspenseWrapper><ItemDetail /></SuspenseWrapper>} />
-              <Route path="items/:id/edit" element={<SuspenseWrapper><ItemForm /></SuspenseWrapper>} />
+              <Route
+                path="items/:id/edit"
+                element={
+                  <AdminRoute>
+                    <SuspenseWrapper><ItemForm /></SuspenseWrapper>
+                  </AdminRoute>
+                }
+              />
               
               {/* Categories Routes */}
               <Route path="categories" element={<SuspenseWrapper><CategoryList /></SuspenseWrapper>} />
@@ -90,10 +112,38 @@ function App() {
               <Route path="reports" element={<SuspenseWrapper><Reports /></SuspenseWrapper>} />
               
               {/* Users Routes (Admin Only) */}
-              <Route path="users" element={<SuspenseWrapper><UserList /></SuspenseWrapper>} />
-              <Route path="users/create" element={<SuspenseWrapper><UserForm /></SuspenseWrapper>} />
-              <Route path="users/:id" element={<SuspenseWrapper><UserDetail /></SuspenseWrapper>} />
-              <Route path="users/:id/edit" element={<SuspenseWrapper><UserForm /></SuspenseWrapper>} />
+              <Route
+                path="users"
+                element={
+                  <AdminRoute>
+                    <SuspenseWrapper><UserList /></SuspenseWrapper>
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="users/create"
+                element={
+                  <AdminRoute>
+                    <SuspenseWrapper><UserForm /></SuspenseWrapper>
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="users/:id"
+                element={
+                  <AdminRoute>
+                    <SuspenseWrapper><UserDetail /></SuspenseWrapper>
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="users/:id/edit"
+                element={
+                  <AdminRoute>
+                    <SuspenseWrapper><UserForm /></SuspenseWrapper>
+                  </AdminRoute>
+                }
+              />
               
               {/* Profile & Settings Routes */}
               <Route path="profile" element={<SuspenseWrapper><Profile /></SuspenseWrapper>} />

--- a/frontend/src/pages/CategoryList.jsx
+++ b/frontend/src/pages/CategoryList.jsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react';
 import CategoryForm from '../components/CategoryForm';
+import { authService } from '../services/authService';
 import { categoryService } from '../services/categoryService';
 
 function CategoryList() {
+  const isAdmin = authService.isAdmin();
   const [categories, setCategories] = useState([]);
   const [loading, setLoading] = useState(true);
   const [showModal, setShowModal] = useState(false);
@@ -81,15 +83,17 @@ function CategoryList() {
               className="pl-10 pr-4 py-2 w-full border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             />
           </div>
-          <button
-            onClick={handleCreate}
-            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center space-x-2 whitespace-nowrap"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-            </svg>
-            <span>Tambah Kategori</span>
-          </button>
+          {isAdmin && (
+            <button
+              onClick={handleCreate}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center space-x-2 whitespace-nowrap"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+              </svg>
+              <span>Tambah Kategori</span>
+            </button>
+          )}
         </div>
       </div>
 
@@ -126,9 +130,11 @@ function CategoryList() {
                   <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Jumlah Barang
                   </th>
-                  <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Aksi
-                  </th>
+                  {isAdmin && (
+                    <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Aksi
+                    </th>
+                  )}
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
@@ -150,26 +156,28 @@ function CategoryList() {
                         {category.items_count || 0} barang
                       </span>
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-center text-sm font-medium">
-                      <button
-                        onClick={() => handleEdit(category)}
-                        className="text-blue-600 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300 mr-3 transition-colors"
-                        title="Edit"
-                      >
-                        <svg className="w-5 h-5 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                        </svg>
-                      </button>
-                      <button
-                        onClick={() => handleDelete(category.id)}
-                        className="text-red-600 dark:text-red-400 hover:text-red-900 dark:hover:text-red-300 transition-colors"
-                        title="Hapus"
-                      >
-                        <svg className="w-5 h-5 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                        </svg>
-                      </button>
-                    </td>
+                    {isAdmin && (
+                      <td className="px-6 py-4 whitespace-nowrap text-center text-sm font-medium">
+                        <button
+                          onClick={() => handleEdit(category)}
+                          className="text-blue-600 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300 mr-3 transition-colors"
+                          title="Edit"
+                        >
+                          <svg className="w-5 h-5 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                          </svg>
+                        </button>
+                        <button
+                          onClick={() => handleDelete(category.id)}
+                          className="text-red-600 dark:text-red-400 hover:text-red-900 dark:hover:text-red-300 transition-colors"
+                          title="Hapus"
+                        >
+                          <svg className="w-5 h-5 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                          </svg>
+                        </button>
+                      </td>
+                    )}
                   </tr>
                 ))}
               </tbody>

--- a/frontend/src/pages/ItemDetail.jsx
+++ b/frontend/src/pages/ItemDetail.jsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
+import { authService } from '../services/authService';
 import { itemService } from '../services/itemService';
 
 function ItemDetail() {
+  const isAdmin = authService.isAdmin();
   const { id } = useParams();
   const navigate = useNavigate();
   const [item, setItem] = useState(null);
@@ -63,15 +65,17 @@ function ItemDetail() {
             <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{item.name}</h1>
             <p className="text-gray-600 dark:text-gray-400 mt-1">Kode: {item.code}</p>
           </div>
-          <Link
-            to={`/items/${item.id}/edit`}
-            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center space-x-2"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-            </svg>
-            <span>Edit</span>
-          </Link>
+          {isAdmin && (
+            <Link
+              to={`/items/${item.id}/edit`}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center space-x-2"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+              </svg>
+              <span>Edit</span>
+            </Link>
+          )}
         </div>
       </div>
 

--- a/frontend/src/pages/ItemList.jsx
+++ b/frontend/src/pages/ItemList.jsx
@@ -2,10 +2,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useDebounce } from '../hooks/useDebounce';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
+import { authService } from '../services/authService';
 import { categoryService } from '../services/categoryService';
 import { itemService } from '../services/itemService';
 
 function ItemList() {
+  const isAdmin = authService.isAdmin();
   const [items, setItems] = useState([]);
   const [categories, setCategories] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -186,15 +188,17 @@ function ItemList() {
             </button>
           </div>
 
-          <Link
-            to="/items/create"
-            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center space-x-2 text-sm font-medium shadow-sm"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-            </svg>
-            <span>Tambah Barang</span>
-          </Link>
+          {isAdmin && (
+            <Link
+              to="/items/create"
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center space-x-2 text-sm font-medium shadow-sm"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+              </svg>
+              <span>Tambah Barang</span>
+            </Link>
+          )}
         </div>
       </div>
 
@@ -322,18 +326,22 @@ function ItemList() {
                         >
                           Detail
                         </Link>
-                        <Link
-                          to={`/items/${item.id}/edit`}
-                          className="text-indigo-600 dark:text-indigo-400 hover:text-indigo-900 dark:hover:text-indigo-300 mr-3"
-                        >
-                          Edit
-                        </Link>
-                        <button
-                          onClick={() => handleDelete(item.id)}
-                          className="text-red-600 dark:text-red-400 hover:text-red-900 dark:hover:text-red-300"
-                        >
-                          Hapus
-                        </button>
+                        {isAdmin && (
+                          <>
+                            <Link
+                              to={`/items/${item.id}/edit`}
+                              className="text-indigo-600 dark:text-indigo-400 hover:text-indigo-900 dark:hover:text-indigo-300 mr-3"
+                            >
+                              Edit
+                            </Link>
+                            <button
+                              onClick={() => handleDelete(item.id)}
+                              className="text-red-600 dark:text-red-400 hover:text-red-900 dark:hover:text-red-300"
+                            >
+                              Hapus
+                            </button>
+                          </>
+                        )}
                       </td>
                     </tr>
                   ))}

--- a/frontend/src/test/components/RbacVisibility.test.jsx
+++ b/frontend/src/test/components/RbacVisibility.test.jsx
@@ -1,0 +1,201 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import CategoryList from '../../pages/CategoryList';
+import ItemDetail from '../../pages/ItemDetail';
+import ItemList from '../../pages/ItemList';
+import { authService } from '../../services/authService';
+import { categoryService } from '../../services/categoryService';
+import { itemService } from '../../services/itemService';
+
+vi.mock('../../services/authService', () => ({
+  authService: {
+    isAdmin: vi.fn(),
+    getCurrentUser: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/itemService', () => ({
+  itemService: {
+    getAll: vi.fn(),
+    getById: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/categoryService', () => ({
+  categoryService: {
+    getAll: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+const mockItemsResponse = {
+  data: [
+    {
+      id: 1,
+      code: 'ITM-001',
+      name: 'Laptop Dell Latitude',
+      description: 'Laptop kantor',
+      category: { id: 1, name: 'Elektronik' },
+      stock: 10,
+      available_stock: 8,
+      condition: 'baik',
+    },
+  ],
+  last_page: 1,
+};
+
+const mockItemDetailResponse = {
+  data: {
+    id: 1,
+    code: 'ITM-001',
+    name: 'Laptop Dell Latitude',
+    description: 'Laptop kantor',
+    category: { id: 1, name: 'Elektronik' },
+    stock: 10,
+    available_stock: 8,
+    condition: 'baik',
+    created_at: '2026-01-01T00:00:00.000000Z',
+    updated_at: '2026-01-01T00:00:00.000000Z',
+    active_borrowings: [],
+  },
+};
+
+const mockCategoriesResponse = {
+  data: [
+    {
+      id: 1,
+      name: 'Elektronik',
+      description: 'Peralatan elektronik',
+      items_count: 5,
+    },
+  ],
+};
+
+describe('Role-Based Access Control (RBAC) UI Visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    itemService.getAll.mockResolvedValue(mockItemsResponse);
+    itemService.getById.mockResolvedValue(mockItemDetailResponse);
+    categoryService.getAll.mockResolvedValue(mockCategoriesResponse);
+  });
+
+  describe('ItemList Component', () => {
+    it('renders Tambah Barang, Edit, and Hapus buttons for Admin', async () => {
+      authService.isAdmin.mockReturnValue(true);
+
+      render(
+        <MemoryRouter>
+          <ItemList />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Laptop Dell Latitude')).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole('link', { name: /Tambah Barang/i })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Edit' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Hapus' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Detail' })).toBeInTheDocument();
+    });
+
+    it('hides Tambah Barang, Edit, and Hapus buttons for Staff, only showing Detail', async () => {
+      authService.isAdmin.mockReturnValue(false);
+
+      render(
+        <MemoryRouter>
+          <ItemList />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Laptop Dell Latitude')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByRole('link', { name: /Tambah Barang/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'Edit' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Hapus' })).not.toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Detail' })).toBeInTheDocument();
+    });
+  });
+
+  describe('CategoryList Component', () => {
+    it('renders Tambah Kategori and Aksi column for Admin', async () => {
+      authService.isAdmin.mockReturnValue(true);
+
+      render(
+        <MemoryRouter>
+          <CategoryList />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Elektronik')).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole('button', { name: /Tambah Kategori/i })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Aksi' })).toBeInTheDocument();
+      expect(screen.getByTitle('Edit')).toBeInTheDocument();
+      expect(screen.getByTitle('Hapus')).toBeInTheDocument();
+    });
+
+    it('hides Tambah Kategori and Aksi column for Staff', async () => {
+      authService.isAdmin.mockReturnValue(false);
+
+      render(
+        <MemoryRouter>
+          <CategoryList />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Elektronik')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByRole('button', { name: /Tambah Kategori/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('columnheader', { name: 'Aksi' })).not.toBeInTheDocument();
+      expect(screen.queryByTitle('Edit')).not.toBeInTheDocument();
+      expect(screen.queryByTitle('Hapus')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('ItemDetail Component', () => {
+    it('renders Edit button for Admin', async () => {
+      authService.isAdmin.mockReturnValue(true);
+
+      render(
+        <MemoryRouter initialEntries={['/items/1']}>
+          <Routes>
+            <Route path="/items/:id" element={<ItemDetail />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { level: 1, name: 'Laptop Dell Latitude' })).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole('link', { name: /Edit/i })).toBeInTheDocument();
+    });
+
+    it('hides Edit button for Staff', async () => {
+      authService.isAdmin.mockReturnValue(false);
+
+      render(
+        <MemoryRouter initialEntries={['/items/1']}>
+          <Routes>
+            <Route path="/items/:id" element={<ItemDetail />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { level: 1, name: 'Laptop Dell Latitude' })).toBeInTheDocument();
+      });
+
+      expect(screen.queryByRole('link', { name: /Edit/i })).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Deskripsi
Pull Request ini mengimplementasikan pembatasan visibilitas antarmuka (Role-Based Access Control / RBAC) pada menu Barang dan Kategori untuk pengguna dengan role `staff`, serta memproteksi route admin dari akses URL langsung.

Closes #76

## Ringkasan Perubahan
1. **ItemList (`frontend/src/pages/ItemList.jsx`)**:
   - Menyembunyikan tombol "Tambah Barang" untuk role staff.
   - Menyembunyikan aksi "Edit" dan "Hapus" pada tabel untuk role staff, sehingga hanya aksi "Detail" yang dapat diakses.
2. **CategoryList (`frontend/src/pages/CategoryList.jsx`)**:
   - Menyembunyikan tombol "Tambah Kategori" untuk role staff.
   - Menyembunyikan kolom "Aksi" pada tabel (baik header `<th>` maupun sel aksi edit dan hapus) untuk role staff.
3. **ItemDetail (`frontend/src/pages/ItemDetail.jsx`)**:
   - Menyembunyikan tombol "Edit" di bagian header untuk role staff.
4. **App Routing (`frontend/src/App.jsx`)**:
   - Menambahkan komponen route guard `AdminRoute` yang mengarahkan pengguna non-admin (staff) kembali ke `/dashboard` jika mengakses rute admin secara langsung.
   - Memproteksi rute `/items/create`, `/items/:id/edit`, dan semua sub-rute `/users/*`.
5. **Unit Testing (`frontend/src/test/components/RbacVisibility.test.jsx`)**:
   - Menambahkan automated unit tests untuk memverifikasi visibilitas elemen UI pada role Admin dan Staff pada komponen `ItemList`, `CategoryList`, dan `ItemDetail`.

## Verifikasi
- **Automated Tests**:
  - `npm test -- --run` lulus seluruhnya (9 test files, 62 unit tests passed).
- **Production Build**:
  - `npm run build` sukses tanpa error (Vite production build).
- **Verifikasi Live Browser (Chrome DevTools MCP)**:
  - Role Staff:
    - Halaman `/items`: Tombol "Tambah Barang", "Edit", dan "Hapus" tidak muncul; hanya tombol "Detail" yang tersedia.
    - Halaman `/categories`: Tombol "Tambah Kategori" dan seluruh kolom "Aksi" tidak muncul.
    - Halaman `/items/1`: Tombol "Edit" di header tidak muncul.
    - Akses langsung ke `/items/create`, `/items/1/edit`, dan `/users` langsung dialihkan ke `/dashboard`.
  - Role Admin:
    - Halaman `/items`: Tombol "Tambah Barang", "Detail", "Edit", dan "Hapus" tampil lengkap.
    - Halaman `/categories`: Tombol "Tambah Kategori" dan kolom "Aksi" tampil lengkap.
    - Halaman `/items/1`: Tombol "Edit" tampil di header.
    - Rute admin dapat diakses seperti biasa.
